### PR TITLE
feat(twitch): fine-tune response lag presets for Aivis/TTS environment

### DIFF
--- a/src/services/twitch_service.py
+++ b/src/services/twitch_service.py
@@ -20,9 +20,9 @@ class TwitchService:
 
         presets = {
             "instant": [0.0, 0.0],
-            "fast":    [0.1, 0.03],
-            "natural": [0.2, 0.07],
-            "slow":    [0.5, 0.12],
+            "fast":    [0.1, 0.12],
+            "natural": [0.2, 0.16],
+            "slow":    [0.3, 0.20],
         }
         base, spw = presets.get(speed, presets["natural"])
 

--- a/tests/test_twitch_logic.py
+++ b/tests/test_twitch_logic.py
@@ -169,9 +169,9 @@ async def test_twitch_wait_time_calculation():
 
     # 2. Natural mode (base 0.2s + weighted char count)
     server.config.get = MagicMock(return_value={"response_speed": "natural"})
-    # "あ" (1) -> 0.2 + 1 * 0.07 = 0.27
-    assert server.twitch_service._calculate_wait_time("あ") == pytest.approx(0.27)
-    # "漢" (2) -> 0.2 + 2 * 0.07 = 0.34
-    assert server.twitch_service._calculate_wait_time("漢") == pytest.approx(0.34)
+    # "あ" (1) -> 0.2 + 1 * 0.16 = 0.36
+    assert server.twitch_service._calculate_wait_time("あ") == pytest.approx(0.36)
+    # "漢" (2) -> 0.2 + 2 * 0.16 = 0.52
+    assert server.twitch_service._calculate_wait_time("漢") == pytest.approx(0.52)
     # "！" (ignored) -> 0.2 + 0 = 0.2
     assert server.twitch_service._calculate_wait_time("！") == pytest.approx(0.2)


### PR DESCRIPTION
## Overview
Optimized Twitch chat response timing to align with the parallel LLM request logic. This tuning minimizes unnecessary waiting while ensuring the AI doesn't overlap with the initial TTS reading lag.

## Changes
- **Twitch Service Presets**: Updated `base` and `spw` (seconds per weight) for all speed modes.
  - `natural`: Base 0.2s / SPW 0.16s
  - `fast`: Base 0.1s / SPW 0.12s
  - `slow`: Base 0.3s / SPW 0.20s
- **Unit Tests**: Updated `tests/test_twitch_logic.py` to reflect the new calculation values.

## Verification
- [x] Ran `uv run pytest tests/test_twitch_logic.py` - All 7 tests passed.
- [x] Verified timings based on user-provided logs.