### PR TITLE
fix(sidecar): upgrade Sidecar Runtime to Python 3.13.12 to fix ImportError

### DIFF
--- a/scripts/prepare_sidecar.sh
+++ b/scripts/prepare_sidecar.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Configuration
+# Updated to match project Python version and latest standalone build
 PYTHON_VERSION="3.13.12"
 BUILD_TAG="20260203"
 PLATFORM="aarch64-apple-darwin"
@@ -11,31 +12,45 @@ RESOURCE_DIR="electron/resources"
 BIN_DIR="${RESOURCE_DIR}/bin"
 SITE_PACKAGES_DIR="${RESOURCE_DIR}/site-packages"
 
-echo "🚀 Preparing Sidecar Resources..."
+echo "🚀 Preparing Sidecar Resources (Python ${PYTHON_VERSION})..."
 
 # 1. Create directories
 mkdir -p "${BIN_DIR}"
 mkdir -p "${SITE_PACKAGES_DIR}"
 mkdir -p "electron/build"
 
-# 2. Download Portable Python if not exists
-if [ ! -f "${BIN_DIR}/python-runtime/bin/python3" ]; then
-    echo "📥 Downloading Portable Python (${PYTHON_VERSION})..."
+# 2. Download Portable Python if not exists (or if version mismatch)
+# We check the version file if it exists to ensure we have the right one
+CURRENT_VER=""
+if [ -f "${BIN_DIR}/python-runtime/BIN_VERSION" ]; then
+    CURRENT_VER=$(cat "${BIN_DIR}/python-runtime/BIN_VERSION")
+fi
+
+if [ "${CURRENT_VER}" != "${PYTHON_VERSION}+${BUILD_TAG}" ]; then
+    echo "📥 Downloading Portable Python ${PYTHON_VERSION} (Tag: ${BUILD_TAG})..."
+    rm -rf "${BIN_DIR}/python-runtime"
     curl -L "${URL}" -o "python-standalone.tar.gz"
     mkdir -p "${BIN_DIR}/python-runtime"
     tar -xzf "python-standalone.tar.gz" -C "${BIN_DIR}/python-runtime" --strip-components=1
+    echo "${PYTHON_VERSION}+${BUILD_TAG}" > "${BIN_DIR}/python-runtime/BIN_VERSION"
     rm "python-standalone.tar.gz"
-    echo "✅ Python downloaded."
+    echo "✅ Python downloaded and installed."
 else
-    echo "ℹ️ Portable Python already exists."
+    echo "ℹ️ Portable Python ${PYTHON_VERSION} already exists."
 fi
 
-# 3. Export site-packages (excluding heavy ones we stub)
+# 3. Export site-packages
 echo "📦 Exporting site-packages from .venv..."
-# Prune torch-related stuff to save space
-# We use 'uv pip install' to a temporary directory to get a clean set of dependencies
-# OR we just copy the current .venv/lib/python3.13/site-packages
-# For now, let's just copy and exclude torch
+# Important: Ensure we use the path for 3.13
+if [ ! -d ".venv/lib/python3.13/site-packages" ]; then
+    echo "❌ Error: .venv/lib/python3.13/site-packages not found."
+    echo "Please run 'uv sync' first."
+    exit 1
+fi
+
+# Clean up old packages to avoid version mixing
+rm -rf "${SITE_PACKAGES_DIR}"/*
+
 rsync -av --progress .venv/lib/python3.13/site-packages/ "${SITE_PACKAGES_DIR}/" \
     --exclude "torch*" \
     --exclude "torchaudio*" \

--- a/uv.lock
+++ b/uv.lock
@@ -1314,7 +1314,7 @@ wheels = [
 
 [[package]]
 name = "parcera"
-version = "0.2.1"
+version = "0.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiavatar" },


### PR DESCRIPTION
## 概要
DMGビルド版で発生していた `ImportError: cannot import name '_populate_finfo_constants' from 'numpy._core._multiarray_umath'` を修正します。

## 原因
- Sidecar（Pythonエンジン）として同梱されている Portable Python のバージョンが以前のアップグレード時に 3.11 のまま残っていたのに対し、`site-packages` としてコピーされていたライブラリ群が Python 3.13 向けにビルドされたものであったため、バイナリ互換性がなくロードに失敗していました。

## 修正内容
- `scripts/prepare_sidecar.sh` を更新し、同梱する Python Runtime を最新の **3.13.12 (Build 20260203)** にアップグレードしました。
- ライブラリのコピー元パスを `.venv/lib/python3.13/` に固定。
- 実行時に Runtime 側の `BIN_VERSION` をチェックするようにし、バージョンの不整合が発生しにくいように改善。

## 動作確認
- [x] `scripts/prepare_sidecar.sh` の実行
- [x] 同梱ランタイムからの `numpy` インポート確認（Python 3.13.12 / Numpy 2.4.2）
- [x] 手動での `site-packages` 整合性チェック

このPRをマージ後、`mise run package` を実行することで正常な DMG が作成されます。