### PR TITLE
feat: real-time sensitivity control and lightweight config updates (v0.2.3)

### DIFF
--- a/.agent/skills/ai-behavior-tuning/SKILL.md
+++ b/.agent/skills/ai-behavior-tuning/SKILL.md
@@ -24,7 +24,21 @@
 3. **時間的違和感 (Temporal Friction)**
    - **Response Fatigue**: 独り言や短い囁きに対して、過剰に反応しすぎていないか？（頻度のミスマッチ）
 
-## 🛠 Step 2: Tuning Layers (修正レイヤーの適用)
+## ⚙️ Step 2: Analytical Tuning (データに基づく解析と調整)
+挙動の違和感を感覚だけで調整するのではなく、実際のログデータに基づいたシミュレーションを行い、最適なパラメータを導き出す。
+
+### 1. ログ解析 (Log Analysis)
+過去の対話ログ（`sample3.log` 等）を解析し、現状の「重み（文字数や漢字の密度）」に対する実際の反応率を可視化する。
+- **Tool**: `scripts/research/analyze_interaction.py`
+- **Metric**: `Actual response rate by weight range` を確認し、どの長さの発話が無視されているか、あるいは反応しすぎているかを特定する。
+
+### 2. パラメータ・シミュレーション (Simulation)
+新しい感度設定（midpoint, slope, max_prob）を適用した場合に、過去のログに対してどれくらいの反応率になるかを事前にシミュレートする。
+- **Execution**: `python scripts/research/analyze_interaction.py sample.log --custom 16.0 0.15 0.45`
+- **Goal**: 平均反応率（Total Expected）が想定範囲内（例: 40-50%）に収まり、かつ短文（Weight 10以下）への反応が適切に抑制されているかを確認する。
+
+## 🛠 Step 3: Tuning Layers (修正レイヤーの適用)
+シミュレーションで得られた最適な数値を適用し、さらに個別のキャラクター表現を磨き上げる。
 
 ### 1. 感度レイヤー (Sensitivity Settings)
 発話の「重み」や「長さ」に対する反応確率を調整する。
@@ -46,6 +60,6 @@
 - **Role Alignment**: 設定された役割（執事、悪友、etc.）が、ユーザーの意図する距離感で出力されているか検証する。
 - **Knowledge Injection**: 汎用的な会話ではなく、特定の状況（ゲームの状況、特定のトピック）に基づいた「生きた知識」を優先的に使うよう誘導する。
 
-## ✅ Step 3: Iterative Refinement (反復改善)
+## ✅ Step 4: Iterative Refinement (反復改善)
 - チューニングは一度で終わらせず、実プレイのログを元に「修正 → 比較 → 再修正」を繰り返す。
 - キャラクターの根幹に関わる修正を行う際は、必ずユーザーの意図（どんな関係性でありたいか）を再確認する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-03-03 - Real-time Interaction Control & Optimization
+
+### Added
+- **Real-time Interaction Controls**: Added direct sensitivity selection (Low/Medium/High) buttons to the AI avatar window for instant behavior adjustment.
+- **Lightweight IPC Mechanism**: Implemented `update-setting` IPC handler for partial, high-speed configuration updates without requiring a full settings reload.
+- **Layered Configuration**: Established a robust three-tier configuration hierarchy: `system_vitals.yaml` (Internal) -> `settings.default.yaml` (UI Defaults) -> `config.json` (User).
+- **Automated Migration**: Added silent config migration to clean up legacy internal constants from user configuration files.
+
+### Changed
+- **Interaction Performance**: Refactored Microphone Mute and Conversation Mode toggles to use the new lightweight update mechanism, significantly reducing UI latency.
+- **Sensitivity Presets**: Updated `ResponseWeightFilter` parameters to a more balanced "Medium" default [16.0, 0.15, 0.45] and decoupled presets from UI settings.
+
+### Fixed
+- **Code Integrity**: Removed redundant `useEffect` hooks and corrected state synchronization logic in `useAvatar`.
+- **Testing**: Added comprehensive test suites for configuration hierarchy and front-end sensitivity controls.
+
 ## [0.2.2] - 2026-03-01 - Python 3.13 & Library Optimization
 
 ### Changed

--- a/configs/settings.default.yaml
+++ b/configs/settings.default.yaml
@@ -9,16 +9,6 @@ log_level: "INFO"      # Logging level: DEBUG, INFO, WARNING, ERROR
 merge_request_threshold: 0.6  # [Seconds] Wait time after STT before LLM starts.
 response_sensitivity: "medium"  # "high" | "medium" | "low"
 
-# Weighted Length Sigmoid Presets: (midpoint, slope, max_prob)
-sensitivity_presets:
-  high:   [15.0, 0.12, 0.75]
-  medium: [22.0, 0.12, 0.40]
-  low:    [25.0, 0.15, 0.30]
-
-# TTS Busy Duration Estimation
-tts_timing:
-  chars_per_second: 6.0
-  buffer_latency: 1.0
 
 force_keywords:       # AI will always respond if these keywords are detected
   - パルセラ
@@ -37,14 +27,12 @@ llm:
       api_key: ""      # Google Gemini API Key
       temperature: 1.0  # Creativity (0.0 - 2.0). Default 1.0 is recommended for Gemini 2.0.
       persist_history: false
-      option_split_threshold: 15
 
     openai:
       model: "gpt-4o"
       api_key: ""      # OpenAI API Key
       temperature: 1.0  # Creativity (0.0 - 2.0). OpenAI default is 1.0.
       persist_history: false
-      option_split_threshold: 15
 
 # ==========================================
 # STT (Speech to Text) Settings
@@ -156,9 +144,6 @@ electron:
 # ==========================================
 avatars:
   show_debug: false       # Show VAD status / Volume bars overlay
-  blink_interval_min: 5000 # [ms] Minimum time between blinks
-  blink_interval_max: 15000 # [ms] Maximum time between blinks
-  mouth_hold_time: 120    # [ms] Minimum duration to hold a mouth shape (prevents flickering)
   breathe_scale: 1.008    # Scaling width for breathing animation (1.0 = no animation)
   breathe_amplitude: 3    # [px] Vertical movement width for breathing
   breathe_duration: 4500  # [ms] Reference period for one breath cycle
@@ -211,7 +196,6 @@ twitch:
   enabled: false
   client_id: ""
   client_secret: ""
-  redirect_uri: "http://localhost:8677/auth/callback"
   wake_word: "パルセラ|Parcera"
   ng_words: []
   ignored_users:

--- a/configs/system_vitals.yaml
+++ b/configs/system_vitals.yaml
@@ -1,0 +1,33 @@
+# ==========================================
+# System-Level Constants (Not for users to edit)
+# ==========================================
+
+# Weighted Length Sigmoid Presets: (midpoint, slope, max_prob)
+# These define the behavior of response sensitivity levels.
+sensitivity_presets:
+  high:   [15.0, 0.12, 0.75]
+  medium: [16.0, 0.15, 0.45]
+  low:    [25.0, 0.15, 0.30]
+
+# TTS Busy Duration Estimation parameters
+tts_timing:
+  chars_per_second: 6.0
+  buffer_latency: 1.0
+
+# Animation & Visual timings (Lower level constants)
+avatars:
+  blink_interval_min: 5000  # [ms]
+  blink_interval_max: 15000 # [ms]
+  mouth_hold_time: 120      # [ms]
+
+# LLM fine-tuning parameters
+llm:
+  providers:
+    gemini:
+      option_split_threshold: 15 # Number of sentences before splitting response
+    openai:
+      option_split_threshold: 15
+
+# Integration Constants
+twitch:
+  redirect_uri: "http://localhost:8677/auth/callback"

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -55,7 +55,37 @@ function getYamlSettingsPath(): string {
   return path.resolve(process.env['APP_ROOT']!, '../configs/settings.default.yaml');
 }
 
+/**
+ * Cleanup configuration keys that are now managed as internal system constants
+ * or have been deprecated/moved. This ensures users pull the latest values
+ * from system_vitals.yaml instead of being stuck with old default copies.
+ */
+function cleanDeprecatedSettings() {
+  const deprecatedKeys = [
+    'sensitivity_presets',
+    'tts_timing',
+    // Nested keys use dot notation in electron-store
+    'llm.providers.gemini.option_split_threshold',
+    'llm.providers.openai.option_split_threshold',
+    'twitch.redirect_uri',
+    'avatars.blink_interval_min',
+    'avatars.blink_interval_max',
+    'avatars.mouth_hold_time',
+  ];
+
+  let changed = false;
+  for (const key of deprecatedKeys) {
+    if (store.has(key)) {
+      console.log(`[Parcera] Migration: Removing deprecated/internal key '${key}' from config.json`);
+      store.delete(key as any);
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 function initializeStore() {
+  // 1. Check if store is completely empty (first run)
   if (Object.keys(store.store).length === 0) {
     console.log('[Parcera] Store is empty, seeding from configs/settings.default.yaml...');
     try {
@@ -68,6 +98,9 @@ function initializeStore() {
     } catch (e) {
       console.error('Failed to seed store from YAML:', e);
     }
+  } else {
+    // 2. Perform migration/cleanup for existing users
+    cleanDeprecatedSettings();
   }
 }
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -75,7 +75,7 @@ function cleanDeprecatedSettings() {
 
   let changed = false;
   for (const key of deprecatedKeys) {
-    if (store.has(key)) {
+    if (store.has(key as any)) {
       console.log(`[Parcera] Migration: Removing deprecated/internal key '${key}' from config.json`);
       store.delete(key as any);
       changed = true;
@@ -478,6 +478,29 @@ ipcMain.handle('save-settings', async (_event, newSettings: ParceraSettings) => 
     return { success: true };
   } catch (e) {
     console.error('Failed to save settings:', e);
+    return { success: false, error: String(e) };
+  }
+});
+
+ipcMain.handle('update-setting', async (_event, key: string, value: any) => {
+  try {
+    // 1. Update the store (electron-store handles dot notation for nested keys)
+    store.set(key, value);
+
+    // 2. Notify Python server to reload config
+    const currentSettings = store.store;
+    const port = currentSettings.electron?.port || 8676;
+    const url = `http://127.0.0.1:${port}/config/reload`;
+
+    fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(currentSettings)
+    }).catch(e => console.warn('[Parcera] Python reload notification failed:', e.message));
+
+    return { success: true };
+  } catch (e) {
+    console.error(`Failed to update setting ${key}:`, e);
     return { success: false, error: String(e) };
   }
 });

--- a/electron/main/preload.ts
+++ b/electron/main/preload.ts
@@ -10,6 +10,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   saveSettings: (settings: ParceraSettings): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke('save-settings', settings),
+  updateSetting: (key: string, value: any): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke('update-setting', key, value),
   getDefaultSettings: (): Promise<ParceraSettings> => ipcRenderer.invoke('get-default-settings'),
   selectDirectory: (currentPath?: string): Promise<string | null> => ipcRenderer.invoke('select-directory', currentPath),
   saveWindowBounds: (type: 'user' | 'ai'): Promise<{ success: boolean; error?: string }> => ipcRenderer.invoke('save-window-bounds', type),

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "parcera",
   "productName": "Parcera",
   "private": true,
-  "version": "0.2.2",
+  "version": "0.2.3",
   "main": "dist-electron/index.js",
   "type": "module",
   "scripts": {

--- a/electron/renderer/components/Avatar.tsx
+++ b/electron/renderer/components/Avatar.tsx
@@ -28,6 +28,8 @@ export const Avatar: React.FC = () => {
     toggleMute,
     toggleMode,
     toggleLock,
+    sensitivity,
+    setSensitivity,
   } = useAvatar();
 
   return (
@@ -75,14 +77,31 @@ export const Avatar: React.FC = () => {
           </button>
 
           {state.avatarType === 'ai' && (
-            <button
-              className={`control-button ${mode === 'conversation' ? 'active' : ''}`}
-              onClick={toggleMode}
-              style={{ fontSize: '14px' }}
-              title={mode === 'conversation' ? "対話モード (おしゃべり中)" : "独り言モード (見守り中)"}
-            >
-              {mode === 'conversation' ? '💬' : '👁️'}
-            </button>
+            <>
+              <div className="sensitivity-selector">
+                {(['low', 'medium', 'high'] as const).map((level) => (
+                  <button
+                    key={level}
+                    className={`sensitivity-button ${sensitivity === level ? 'active' : ''}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setSensitivity(level);
+                    }}
+                    title={`反応感度: ${level}`}
+                  >
+                    {level === 'low' ? 'L' : level === 'medium' ? 'M' : 'H'}
+                  </button>
+                ))}
+              </div>
+              <button
+                className={`control-button ${mode === 'conversation' ? 'active' : ''}`}
+                onClick={toggleMode}
+                style={{ fontSize: '14px' }}
+                title={mode === 'conversation' ? "対話モード (おしゃべり中)" : "独り言モード (見守り中)"}
+              >
+                {mode === 'conversation' ? '💬' : '👁️'}
+              </button>
+            </>
           )}
 
           {state.avatarType === 'user' && (

--- a/electron/renderer/lib/hooks/useAvatar.ts
+++ b/electron/renderer/lib/hooks/useAvatar.ts
@@ -46,76 +46,7 @@ export function useAvatar() {
     }
   }, [isLocked]);
 
-  useEffect(() => {
-    const applySettings = (settings: ParceraSettings) => {
-      state.settings = settings;
 
-      const volumeDb = settings.vad?.volume_db_threshold ?? -20;
-      state.threshold_db = volumeDb;
-      state.threshold = Math.pow(10, volumeDb / 20) * 100;
-      setNoiseGateDb(volumeDb);
-
-      const bScale = settings.avatars?.breathe_scale || 1.005;
-      const bAmp = settings.avatars?.breathe_amplitude || 2;
-      const bDur = settings.avatars?.breathe_duration || 5000;
-      document.documentElement.style.setProperty('--breathe-scale', String(bScale));
-      document.documentElement.style.setProperty('--breathe-amplitude', `${bAmp}px`);
-      document.documentElement.style.setProperty('--breathe-duration', `${bDur}ms`);
-
-      const avatarConfig = settings.avatars?.[state.avatarType] as AvatarConfig | undefined;
-      const rawPath = avatarConfig?.assets_dir || `assets/${state.avatarType}`;
-      const assetsDir = window.electronAPI.resolveLocalPath(rawPath);
-
-      if (avatarImageRef.current) {
-        avatarImageRef.current.src = `${assetsDir}/base.png`;
-      }
-
-      setIsFlipped(avatarConfig?.flip_horizontal ?? false);
-
-      const newMuted = settings.vad?.start_muted ?? false;
-      setIsMuted(newMuted);
-      if (micTrackRef.current) {
-        micTrackRef.current.enabled = !newMuted;
-      }
-
-      const winConf = settings.electron?.windows?.[state.avatarType];
-      if (winConf?.control_corner) {
-        setControlCorner(winConf.control_corner);
-      }
-
-      if (winConf?.locked !== undefined) {
-        setIsLocked(prev => {
-          if (prev === !!winConf.locked) return prev;
-          window.electronAPI.setResizable(!winConf.locked);
-          return !!winConf.locked;
-        });
-      }
-
-      const newMode = settings.user_profile?.mode || 'soliloquy';
-      setMode(prev => (prev === newMode ? prev : newMode));
-
-      const newMicId = settings.electron?.mic_device_id || 'default';
-      setMicId(prev => {
-        if (prev === newMicId) return prev;
-        console.log(`[Parcera] Mic ID changing: ${prev} -> ${newMicId}`);
-        return newMicId;
-      });
-    };
-
-    window.electronAPI.getSettings().then((s: ParceraSettings) => {
-      applySettings(s);
-      updateStatus('Settings Loaded');
-    }).catch((e: any) => {
-      console.error('Settings error:', e);
-      updateStatus('Using Defaults');
-    });
-
-    return window.electronAPI.onSettingsChanged((s: ParceraSettings) => {
-      applySettings(s);
-      updateStatus('Settings Reloaded');
-      console.log('[Parcera] Settings hot-reloaded');
-    });
-  }, []);
 
   useEffect(() => {
     let active = true;
@@ -202,33 +133,106 @@ export function useAvatar() {
     }
   };
 
+  const [sensitivity, setSensitivityState] = useState<'low' | 'medium' | 'high'>('medium');
+
+  useEffect(() => {
+    const applySettings = (settings: ParceraSettings) => {
+      state.settings = settings;
+
+      const volumeDb = settings.vad?.volume_db_threshold ?? -20;
+      state.threshold_db = volumeDb;
+      state.threshold = Math.pow(10, volumeDb / 20) * 100;
+      setNoiseGateDb(volumeDb);
+
+      const bScale = settings.avatars?.breathe_scale || 1.005;
+      const bAmp = settings.avatars?.breathe_amplitude || 2;
+      const bDur = settings.avatars?.breathe_duration || 5000;
+      document.documentElement.style.setProperty('--breathe-scale', String(bScale));
+      document.documentElement.style.setProperty('--breathe-amplitude', `${bAmp}px`);
+      document.documentElement.style.setProperty('--breathe-duration', `${bDur}ms`);
+
+      const avatarConfig = settings.avatars?.[state.avatarType] as AvatarConfig | undefined;
+      const rawPath = avatarConfig?.assets_dir || `assets/${state.avatarType}`;
+      const assetsDir = window.electronAPI.resolveLocalPath(rawPath);
+
+      if (avatarImageRef.current) {
+        avatarImageRef.current.src = `${assetsDir}/base.png`;
+      }
+
+      setIsFlipped(avatarConfig?.flip_horizontal ?? false);
+
+      const newMuted = settings.vad?.start_muted ?? false;
+      setIsMuted(newMuted);
+      if (micTrackRef.current) {
+        micTrackRef.current.enabled = !newMuted;
+      }
+
+      const winConf = settings.electron?.windows?.[state.avatarType];
+      if (winConf?.control_corner) {
+        setControlCorner(winConf.control_corner);
+      }
+
+      if (winConf?.locked !== undefined) {
+        setIsLocked(prev => {
+          if (prev === !!winConf.locked) return prev;
+          window.electronAPI.setResizable(!winConf.locked);
+          return !!winConf.locked;
+        });
+      }
+
+      const newMode = settings.user_profile?.mode || 'soliloquy';
+      setMode(prev => (prev === newMode ? prev : newMode));
+
+      setSensitivityState((settings.response_sensitivity || 'medium') as 'low' | 'medium' | 'high');
+
+      const newMicId = settings.electron?.mic_device_id || 'default';
+      setMicId(prev => {
+        if (prev === newMicId) return prev;
+        console.log(`[Parcera] Mic ID changing: ${prev} -> ${newMicId}`);
+        return newMicId;
+      });
+    };
+
+    window.electronAPI.getSettings().then((s: ParceraSettings) => {
+      applySettings(s);
+      updateStatus('Settings Loaded');
+    }).catch((e: any) => {
+      console.error('Settings error:', e);
+      updateStatus('Using Defaults');
+    });
+
+    return window.electronAPI.onSettingsChanged((s: ParceraSettings) => {
+      applySettings(s);
+      updateStatus('Settings Reloaded');
+      console.log('[Parcera] Settings hot-reloaded');
+    });
+  }, []);
+
   const toggleMute = async (e: React.MouseEvent) => {
     e.stopPropagation();
     const nextMuted = !isMuted;
     setIsMuted(nextMuted);
     if (micTrackRef.current) micTrackRef.current.enabled = !nextMuted;
     updateStatus(nextMuted ? 'Muted' : 'Mic Active');
-
-    const s = await window.electronAPI.getSettings();
-    if (!s.vad) s.vad = {};
-    s.vad.start_muted = nextMuted;
-    await window.electronAPI.saveSettings(s);
+    await window.electronAPI.updateSetting('vad.start_muted', nextMuted);
   };
 
   const toggleMode = async (e: React.MouseEvent) => {
     e.stopPropagation();
-    const s = await window.electronAPI.getSettings();
-    if (!s.user_profile) s.user_profile = {};
-
-    const currentMode = s.user_profile.mode || 'soliloquy';
-    const nextMode = currentMode === 'soliloquy' ? 'conversation' : 'soliloquy';
-
+    const nextMode = mode === 'soliloquy' ? 'conversation' : 'soliloquy';
+    setMode(nextMode);
     updateStatus(`Mode: ${nextMode}`);
-    s.user_profile.mode = nextMode;
-    await window.electronAPI.saveSettings(s);
+    await window.electronAPI.updateSetting('user_profile.mode', nextMode);
+  };
+
+  const setSensitivity = async (level: 'low' | 'medium' | 'high') => {
+    setSensitivityState(level);
+    updateStatus(`Sensitivity: ${level}`);
+    await window.electronAPI.updateSetting('response_sensitivity', level);
   };
 
   const toggleLock = async (e: React.MouseEvent) => {
+    // Keep toggleLock as is for now since it handles multiple fields (bounds + locked)
     e.stopPropagation();
     const nextLocked = !isLocked;
 
@@ -267,10 +271,12 @@ export function useAvatar() {
     isMuted,
     isFlipped,
     mode,
+    sensitivity,
     controlCorner,
     handleImageError,
     toggleMute,
     toggleMode,
     toggleLock,
+    setSensitivity,
   };
 }

--- a/electron/renderer/style.css
+++ b/electron/renderer/style.css
@@ -105,6 +105,48 @@ body.is-locked {
   opacity: 1;
 }
 
+.sensitivity-selector {
+  display: flex;
+  flex-direction: row;
+  gap: 2px;
+  background: rgba(40, 40, 40, 0.8);
+  padding: 3px;
+  border-radius: 12px;
+  opacity: 0;
+  transition: opacity 0.2s;
+  margin-right: 4px;
+}
+
+.controls-wrapper:hover .sensitivity-selector {
+  opacity: 1;
+}
+
+.sensitivity-button {
+  background: transparent;
+  color: #aaa;
+  border: none;
+  font-size: 9px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 800;
+  transition: all 0.2s;
+}
+
+.sensitivity-button:hover {
+  color: #fff;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.sensitivity-button.active {
+  background: #61dafb;
+  color: #000;
+}
+
 .avatar-main {
   width: 100%;
   height: 100%;

--- a/electron/renderer/tests/SensitivityControls.test.tsx
+++ b/electron/renderer/tests/SensitivityControls.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { Avatar } from '../components/Avatar';
+
+// Mock audio/visual to avoid overhead
+vi.mock('../lib/audio', () => ({
+  initAudioContext: vi.fn(),
+  getContext: vi.fn(),
+  getAnalyser: vi.fn(),
+  connectToAnalyser: vi.fn(),
+  setNoiseGateDb: vi.fn(),
+}));
+
+vi.mock('../lib/visual', () => ({
+  initVisual: vi.fn(),
+}));
+
+// Mock Electron API
+const mockElectron = {
+  getSettings: vi.fn().mockResolvedValue({
+    response_sensitivity: 'medium',
+    avatars: { ai: { assets_dir: '/test' } },
+    user_profile: { mode: 'soliloquy' }
+  }),
+  onSettingsChanged: vi.fn(() => vi.fn()),
+  onAvatarSpeechStateChanged: vi.fn(() => vi.fn()),
+  onAvatarBlink: vi.fn(() => vi.fn()),
+  onAvatarLipSyncUpdate: vi.fn(() => vi.fn()),
+  resolveLocalPath: vi.fn((p) => `file://${p}`),
+  getWindowBounds: vi.fn(),
+  setResizable: vi.fn(),
+  saveSettings: vi.fn(),
+  updateSetting: vi.fn().mockResolvedValue({ success: true }),
+  getLogHistory: vi.fn().mockResolvedValue([]),
+};
+(window as any).electronAPI = mockElectron;
+
+import { state } from '../lib/state';
+
+describe('Sensitivity Controls in Avatar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete (window as any).location;
+    (window as any).location = new URL('http://localhost/?type=ai');
+
+    // Manually force state because module-level initialization might have already happened
+    state.avatarType = 'ai';
+  });
+
+  it('renders sensitivity buttons for AI avatar', async () => {
+    render(<Avatar />);
+
+    await waitFor(() => {
+      expect(screen.getByText('L')).toBeInTheDocument();
+      expect(screen.getByText('M')).toBeInTheDocument();
+      expect(screen.getByText('H')).toBeInTheDocument();
+    });
+  });
+
+  it('calls updateSetting when a sensitivity button is clicked', async () => {
+    render(<Avatar />);
+
+    await waitFor(() => {
+      const highBtn = screen.getByText('H');
+      fireEvent.click(highBtn);
+    });
+
+    expect(mockElectron.updateSetting).toHaveBeenCalledWith('response_sensitivity', 'high');
+  });
+
+  it('highlights the active sensitivity level', async () => {
+    mockElectron.getSettings.mockResolvedValueOnce({
+      response_sensitivity: 'low',
+      avatars: { ai: { assets_dir: '/test' } }
+    });
+
+    render(<Avatar />);
+
+    await waitFor(() => {
+      const lowBtn = screen.getByText('L');
+      expect(lowBtn).toHaveClass('active');
+
+      const midBtn = screen.getByText('M');
+      expect(midBtn).not.toHaveClass('active');
+    });
+  });
+});

--- a/electron/shared/types.ts
+++ b/electron/shared/types.ts
@@ -14,7 +14,7 @@ export interface ParceraSettings {
   simple_log?: boolean;                  // If true, only chat logs are shown in terminal
   log_level?: string;                    // "DEBUG" | "INFO" | "WARNING" | "ERROR"
   merge_request_threshold?: number;      // Seconds to merge consecutive requests
-  response_sensitivity?: string;         // "high" | "medium" | "low"
+  response_sensitivity?: 'high' | 'medium' | 'low';
   force_keywords?: string[];
   llm?: LLMSettings;
   stt?: STTSettings;
@@ -220,6 +220,7 @@ export interface ElectronAPI {
   twitchGetAuthStatus: () => Promise<boolean>;
   twitchClearAuth: () => Promise<boolean>;
   onTwitchAuthStatus: (callback: (status: { success: boolean }) => void) => () => void;
+  updateSetting: (key: string, value: any) => Promise<{ success: boolean; error?: string }>;
 }
 
 declare global {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parcera"
-version = "0.2.2"
+version = "0.2.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/research/analyze_interaction.py
+++ b/scripts/research/analyze_interaction.py
@@ -1,0 +1,123 @@
+import os
+import re
+import math
+import argparse
+import yaml
+
+# ==========================================
+# Analytical Tuning Tool
+# ==========================================
+
+class ResponseWeightFilterSim:
+    """Offline simulation of the ResponseWeightFilter logic."""
+    @staticmethod
+    def calculate_weight(text: str) -> float:
+        if not text:
+            return 0.0
+        # Filter out punctuation and whitespace
+        clean_text = re.sub(r'[^\wぁ-んァ-ヶー一-龠]', '', text)
+        raw_len = len(clean_text)
+        kanji_count = len(re.findall(r'[一-龠]', clean_text))
+        return float(raw_len + kanji_count)
+
+    def __init__(self, midpoint, slope, max_prob):
+        self.midpoint = midpoint
+        self.slope = slope
+        self.max_prob = max_prob
+
+    def get_probability(self, text: str) -> float:
+        length = self.calculate_weight(text)
+        if length <= 1:
+            return 0.0
+        # Sigmoid function matching src/core/filters.py
+        return self.max_prob / (1.0 + math.exp(-self.slope * (length - self.midpoint)))
+
+def parse_parcera_log(log_path):
+    """Extracts USER inputs and whether the AI responded from a log file."""
+    interactions = []
+    if not os.path.exists(log_path):
+        print(f"Error: Log file not found at {log_path}")
+        return []
+
+    with open(log_path, "r", encoding="utf-8") as f:
+        # Standard format: [2024-03-02 10:11:42] - user - INFO - [USER (ignored)]: text
+        # Or: [2024-03-02 10:11:42] - user - INFO - [USER]: text
+        for line in f:
+            match = re.search(r'\[USER(\s+\(ignored\))?\]:\s*(.*)', line)
+            if match:
+                is_ignored = match.group(1) is not None
+                text = match.group(2).strip()
+                interactions.append({
+                    "text": text,
+                    "actual_responded": not is_ignored,
+                    "weight": ResponseWeightFilterSim.calculate_weight(text)
+                })
+    return interactions
+
+def load_presets(vitals_path):
+    """Loads presets from system_vitals.yaml."""
+    if os.path.exists(vitals_path):
+        with open(vitals_path, 'r', encoding='utf-8') as f:
+            data = yaml.safe_load(f)
+            return data.get('sensitivity_presets', {})
+    return {}
+
+def main():
+    parser = argparse.ArgumentParser(description="Analyze Parcera interaction logs and simulate response sensitivity.")
+    parser.add_argument("log_file", help="Path to the .log file (e.g., sample3.log)")
+    parser.add_argument("--vitals", default="configs/system_vitals.yaml", help="Path to system_vitals.yaml")
+    parser.add_argument("--custom", nargs=3, type=float, metavar=('MID', 'SLOPE', 'MAX_PROB'), 
+                        help="Test custom parameters [midpoint, slope, max_prob]")
+
+    args = parser.parse_args()
+
+    interactions = parse_parcera_log(args.log_file)
+    if not interactions:
+        return
+
+    presets = load_presets(args.vitals)
+    # Default fallbacks if YAML is missing
+    if not presets:
+        presets = {
+            "high":   [15.0, 0.12, 0.75],
+            "medium": [16.0, 0.15, 0.45],
+            "low":    [25.0, 0.15, 0.30],
+        }
+
+    total = len(interactions)
+    actual_count = sum(1 for i in interactions if i['actual_responded'])
+    avg_weight = sum(i['weight'] for i in interactions) / total
+
+    print(f"📊 --- Log Analysis: {args.log_file} ---")
+    print(f"Total User Inputs : {total}")
+    print(f"Actual AI Responses: {actual_count} ({actual_count/total*100:.1f}%)")
+    print(f"Average Text Weight: {avg_weight:.1f}")
+
+    print("\n📈 Simulation Results (Probabilistic Expected Response Rate):")
+    for name, params in presets.items():
+        sim = ResponseWeightFilterSim(*params)
+        expected = sum(sim.get_probability(i['text']) for i in interactions)
+        print(f"  [{name:6}] Expected: {expected:6.2f} ({expected/total*100:5.1f}%) | Params: {params}")
+
+    if args.custom:
+        sim = ResponseWeightFilterSim(*args.custom)
+        expected = sum(sim.get_probability(i['text']) for i in interactions)
+        print(f"  [CUSTOM] Expected: {expected:6.2f} ({expected/total*100:5.1f}%) | Params: {args.custom}")
+
+    print("\n🔍 Detailed Activity by Weight Range:")
+    ranges = [(0, 5), (6, 10), (11, 20), (21, 50), (51, 100)]
+    for start, end in ranges:
+        sub = [i for i in interactions if start <= i['weight'] <= end]
+        if not sub: continue
+        
+        resp = sum(1 for i in sub if i['actual_responded'])
+        actual_rate = (resp / len(sub)) * 100
+        
+        # Using current 'medium' for comparison
+        med_sim = ResponseWeightFilterSim(*presets.get('medium', [16.0, 0.15, 0.45]))
+        expected_med_rate = (sum(med_sim.get_probability(i['text']) for i in sub) / len(sub)) * 100
+        
+        print(f"  {start:2}-{end:3} W: Count={len(sub):3}, Actual={resp:2} ({actual_rate:5.1f}%), Expected(Med)={expected_med_rate:5.1f}%")
+
+if __name__ == "__main__":
+    main()

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -91,9 +91,17 @@ class ParceraConfig:
         return False
 
     def _load_settings(self, new_settings: dict = None) -> bool:
-        """Load defaults, then overlay user settings. Returns True if settings were updated."""
+        """Load internal system constants, then UI defaults, then user overrides."""
+        vitals_path = os.path.join(self.base_path, "configs", "system_vitals.yaml")
+        vitals = load_config_file(vitals_path)
+
         defaults_path = os.path.join(self.base_path, "configs", "settings.default.yaml")
         defaults = load_config_file(defaults_path)
+
+        # 1. Start with system constants
+        # 2. Layer UI defaults on top
+        # 3. Layer user overrides on top of everything
+        base_settings = deep_merge(vitals, defaults)
 
         user_settings = {}
         if new_settings:
@@ -110,7 +118,7 @@ class ParceraConfig:
                 user_settings = load_config_file(self.settings_path)
                 self.last_mtime = current_mtime
 
-        self.settings = deep_merge(defaults, user_settings)
+        self.settings = deep_merge(base_settings, user_settings)
         return True
 
     def _build_prompts(self):

--- a/src/core/filters.py
+++ b/src/core/filters.py
@@ -24,9 +24,9 @@ class ResponseWeightFilter:
     def __init__(self, force_keywords=None, ignore_sentences=None, sensitivity="medium", presets=None):
         # Default presets if none provided (as fallback)
         self.presets = presets or {
-            "high":   [12.0, 0.15, 0.80],
-            "medium": [18.0, 0.10, 0.60],
-            "low":    [20.0, 0.12, 0.50],
+            "high":   [15.0, 0.12, 0.75],
+            "medium": [16.0, 0.15, 0.45],
+            "low":    [25.0, 0.15, 0.30],
         }
 
         # Initial state from arguments

--- a/tests/test_config_hierarchy.py
+++ b/tests/test_config_hierarchy.py
@@ -1,0 +1,70 @@
+import pytest
+import yaml
+import os
+from unittest.mock import patch, mock_open
+from src.core.config import ParceraConfig
+
+def test_config_hierarchy_merging():
+    # 1. system_vitals.yaml (Base)
+    vitals_yaml = """
+sensitivity_presets:
+  high: [10.0, 0.1, 0.9]
+  medium: [20.0, 0.1, 0.9]
+tts_timing:
+  chars_per_second: 5.0
+"""
+    # 2. settings.default.yaml (Defaults)
+    default_settings_yaml = """
+verbose: false
+response_sensitivity: medium
+llm:
+  provider: gemini
+"""
+    # 3. config.json (User override)
+    user_config_json = """
+{
+  "verbose": true,
+  "log_level": "DEBUG",
+  "response_sensitivity": "high",
+  "llm": {
+    "provider": "openai"
+  }
+}
+"""
+
+    # Mocking paths based on how ParceraConfig builds them
+    def mock_exists(path):
+        if "system_vitals.yaml" in path: return True
+        if "settings.default.yaml" in path: return True
+        # The user override path is the one passed to __init__ or from env
+        if "config.json" in path: return True
+        return False
+
+    def mocked_open(path, *args, **kwargs):
+        if "system_vitals.yaml" in path:
+            return mock_open(read_data=vitals_yaml).return_value
+        if "settings.default.yaml" in path:
+            return mock_open(read_data=default_settings_yaml).return_value
+        if "config.json" in path:
+            return mock_open(read_data=user_config_json).return_value
+        return mock_open().return_value
+
+    with patch("os.path.exists", side_effect=mock_exists), \
+         patch("builtins.open", side_effect=mocked_open), \
+         patch("os.path.getmtime", return_value=123.456):
+        
+        # We pass config.json as the settings_path which is the "user override" layer in current impl
+        config = ParceraConfig(settings_path="config.json")
+        
+        # Check hierarchy
+        # From User: verbose=True, sensitivity=high, llm.provider=openai
+        assert config.verbose is True
+        assert config.get("response_sensitivity") == "high"
+        assert config.get("llm").get("provider") == "openai"
+        
+        # From System Vitals: tts_timing.chars_per_second=5.0
+        assert config.get("tts_timing").get("chars_per_second") == 5.0
+        
+        # From System Vitals (inherited): sensitivity_presets
+        presets = config.get("sensitivity_presets")
+        assert presets["high"] == [10.0, 0.1, 0.9]

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -70,13 +70,13 @@ def test_filter_length_probability():
 def test_filter_sensitivity_presets():
     # High sensitivity should be more chatty (lower midpoint)
     f_high = ResponseWeightFilter(sensitivity="high")
-    assert f_high.midpoint == 12.0
+    assert f_high.midpoint == 15.0
 
     # Low sensitivity should be quiet (higher midpoint)
     f_low = ResponseWeightFilter(sensitivity="low")
-    assert f_low.midpoint == 20.0
+    assert f_low.midpoint == 25.0
 
     # Unknown sensitivity should fallback
     f_unknown = ResponseWeightFilter(sensitivity="super-chatty")
     assert f_unknown.sensitivity == "super-chatty"
-    assert f_unknown.midpoint == 18.0 # default medium
+    assert f_unknown.midpoint == 16.0 # new default medium


### PR DESCRIPTION
## 概要 / Overview
AI の反応感度（Response Sensitivity）をリアルタイムで、かつ効率的に調整できる仕組みを導入しました。
設定画面を開くことなく、AI アバターのウインドウから直接「低・中・高」をワンクリックで切り替えられるようになります。

## 変更点 / Changes
### 1. リアルタイム感度コントロール
- AI ウインドウ（AI タイプ時のみ）に、感度切り替えボタン（**L / M / H**）を追加しました。
- マウスオーバー時のみ表示される premium なデザインを採用しています。

### 2. 軽量設定更新 IPC (`update-setting`)
- 設定全体を書き換えるのではなく、特定のキーのみを更新できる高速な IPC ハンドラを実装しました。
- マイクのミュートや会話モードの切り替えもこの仕組みに移行し、UI のレスポンスを改善しました。

### 3. 設定の階層化と自動クリーンアップ
- 内部的な計算定数を `configs/system_vitals.yaml` に分離しました。
- ユーザーの `config.json` に残っている古い定数を自動で削除するマイグレーション機能を実装。

### 4. テストスイートの拡充
- 設定の優先順位（階層構造）が正しく機能しているかを検証する Python テストを追加。
- Renderer 側で感度ボタンが正しく IPC を呼び出すことを確認する Vitest を追加。

## バージョンアップ
- `var 0.2.3` へバンプ。

## 影響範囲 / Scope
- Electron Main / Preload / Renderer
- Python Backend (Config loading, Response Filter)
- Shared Types