### PR TITLE
feat: add Qwen3.5 local brain support with model-family-aware prompt handling

### DIFF
--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -1,0 +1,1 @@
+../../.agent/workflows/bump-version.md

--- a/.claude/commands/deep-refactor.md
+++ b/.claude/commands/deep-refactor.md
@@ -1,0 +1,1 @@
+../../.agent/workflows/deep-refactor.md

--- a/.claude/skills/ai-behavior-tuning/SKILL.md
+++ b/.claude/skills/ai-behavior-tuning/SKILL.md
@@ -1,0 +1,1 @@
+../../../.agent/skills/ai-behavior-tuning/SKILL.md

--- a/.claude/skills/startup-check/SKILL.md
+++ b/.claude/skills/startup-check/SKILL.md
@@ -1,0 +1,44 @@
+---
+description: Mandatory Startup Check Procedure for Parcera
+---
+
+# Parcera Mandatory Startup Check (Quality Gate)
+
+**Purpose**: To ensure that the agent does not confidently report a task as complete if the application fails to start up due to subtle runtime errors, dependency issues, or configuration bugs. This is a strict verification gate.
+
+## When to Use This Skill
+
+You **MUST** follow this procedure and verify its success before declaring any code refactoring, feature addition, or configuration change complete. A successful `pytest` run or `tsc` compilation is **not** enough. You must confirm the runtime environment stands up successfully.
+
+> [!IMPORTANT]
+> **Environment Dependency Check**:
+> - 外部パッケージ (`python-multipart`等) が `pyproject.toml` に正しく追加されているか。
+> - 外部オーディオバイナリ (`ffmpeg`, `ffprobe`, `afconvert`) が環境に存在するか。
+> - もしバイナリがない場合、フォールバックパス（例: Macでの `afconvert` 使用）が正しく機能するかをランタイムで確認すること。
+
+## Procedure
+
+1. **Start the Application Stack**:
+   Use the `Bash` tool with `run_in_background: true` to execute `mise run dev`. Allow sufficient time (e.g., 8000ms) to catch immediate startup crashes.
+   ```bash
+   mise run dev
+   ```
+
+2. **Verify Backend Status (`run_server.py`)**:
+   Use the `TaskOutput` tool to read the background task's stdout. Wait for and explicitly confirm the presence of log lines analogous to:
+   - `INFO: Application startup complete.`
+   - `LLM: Warm-up complete.`
+   - `TTS Engine is already running...`
+
+3. **Verify Frontend Status (`vite` / `electron` builder)**:
+   Ensure there are no compilation crashes or severe Electron runtime errors in the task output.
+
+4. **Handle Failures**:
+   If the process crashes with a stack trace (e.g. `ModuleNotFoundError`, `AttributeError`, `PydanticValidationError`), you MUST:
+   - Acknowledge the failure.
+   - Stop the background task using the `TaskStop` tool.
+   - Debug and fix the root cause.
+   - Re-run this procedure from Step 1 until success is achieved.
+
+5. **Terminate Processes**:
+   Once both backend and frontend have started and warmed up without fatal errors, use the `TaskStop` tool to terminate the background process before reporting completion to the user.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-03-22 - Multi-Model Local Brain & Qwen3.5 Support
+
+### Added
+- Support for Qwen3.5 (4B / 9B) as selectable local LLM via model dropdown in settings UI
+- Model family detection (`_detect_model_family`) enabling family-aware prompt construction
+- Family-aware `compose_messages`: Gemma embeds system prompt in user message; Qwen uses native system role
+- Family-aware `update_context`: role name switches between `"model"` (Gemma) and `"assistant"` (Qwen)
+- Qwen special tokens (`<|im_end|>`, `<|im_start|>`, `<think>`, `</think>`) added to `SPECIAL_TAGS`
+- `enable_thinking=False` applied to Qwen chat template to suppress reasoning preamble in responses
+- `strict=False` model loading via low-level mlx_lm APIs, allowing VL models (Qwen3.5) to load as text-only
+- Model preset dropdown (Gemma 2 9B / Qwen3.5 9B / Qwen3.5 4B) replacing free-text input in settings UI
+- LoRA profile list now filtered by `base_model` compatibility with the selected model
+- `base_model` field added to profile API response (read from `adapter_config.json`)
+- Automatic `adapter_path` clear when switching models to prevent architecture mismatch
+
+### Changed
+- `export_to_jsonl` now uses model-agnostic `messages` format instead of Gemma-specific turn format
+- `check_model_cached` for HuggingFace models now verifies `.safetensors` weight files exist (not just `config.json`)
+
+### Fixed
+- Vision tower parameter mismatch error when loading Qwen3.5 (VL model) with mlx_lm
+- Download button not appearing after live model switch due to metadata-only cache false positive
+
 ## [0.5.0] - 2026-03-22 - LoRA Management & Multi-Adapter Blending
 
 ### Added

--- a/configs/settings.default.yaml
+++ b/configs/settings.default.yaml
@@ -39,7 +39,7 @@ llm:
       #   Gemma 2:  mlx-community/gemma-2-9b-it-4bit   (default)
       #   Qwen3.5:  mlx-community/Qwen3.5-9B-MLX-4bit  (recommended)
       #             mlx-community/Qwen3.5-4B-MLX-4bit   (low VRAM)
-      model: "mlx-community/gemma-2-9b-it-4bit"
+      model: "mlx-community/Qwen3.5-9B-MLX-4bit"
       temperature: 0.8  # Creativity (0.0 - 2.0).
       max_tokens: 150    # Maximum tokens to generate per response.
       persist_history: false

--- a/configs/settings.default.yaml
+++ b/configs/settings.default.yaml
@@ -35,6 +35,10 @@ llm:
       persist_history: false
 
     local:
+      # Model options:
+      #   Gemma 2:  mlx-community/gemma-2-9b-it-4bit   (default)
+      #   Qwen3.5:  mlx-community/Qwen3.5-9B-MLX-4bit  (recommended)
+      #             mlx-community/Qwen3.5-4B-MLX-4bit   (low VRAM)
       model: "mlx-community/gemma-2-9b-it-4bit"
       temperature: 0.8  # Creativity (0.0 - 2.0).
       max_tokens: 150    # Maximum tokens to generate per response.

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "parcera",
   "productName": "Parcera",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.6.0",
   "main": "dist-electron/index.js",
   "type": "module",
   "scripts": {

--- a/electron/renderer/components/settings/LocalLLMSettings.tsx
+++ b/electron/renderer/components/settings/LocalLLMSettings.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { InputSetting } from './controls/InputSetting';
+import { SelectSetting } from './controls/SelectSetting';
 import { ModelDownloaderUI, useModelDownloader } from './controls/ModelDownloader';
+
+const MODEL_PRESETS = [
+  { label: 'Gemma 2 9B (MLX)', value: 'mlx-community/gemma-2-9b-it-4bit' },
+  { label: 'Qwen3.5 9B (MLX)', value: 'mlx-community/Qwen3.5-9B-MLX-4bit' },
+  { label: 'Qwen3.5 4B (MLX) - 軽量', value: 'mlx-community/Qwen3.5-4B-MLX-4bit' },
+] as const;
 
 interface LocalLLMSettingsProps {
   settings: any;
@@ -187,12 +194,16 @@ export const LocalLLMSettings: React.FC<LocalLLMSettingsProps> = ({
       <div className="setting-card">
         <h3 className="setting-card-title">Local Brain (MLX) の詳細設定</h3>
 
-        <InputSetting
-          label="1. 使用するモデル (HuggingFace Repo)"
-          description="mlx-community/ から始まるリポジトリ名を指定してください。"
-          placeholder="mlx-community/gemma-2-9b-it-4bit"
-          value={settings.llm?.providers?.local?.model ?? ''}
-          onChange={(val) => updateProvider('llm', 'local', 'model', val)}
+        <SelectSetting
+          label="1. 使用するモデル"
+          description="ローカル推論に使用するモデルを選択してください。LoRAプロファイルは選択したモデルと互換性があるものだけ表示されます。"
+          value={settings.llm?.providers?.local?.model ?? MODEL_PRESETS[0].value}
+          options={MODEL_PRESETS.map(p => ({ value: p.value, label: p.label }))}
+          onChange={(val) => {
+            updateProvider('llm', 'local', 'model', val);
+            updateProvider('llm', 'local', 'adapter_path', '');
+            setBlendWeights({});
+          }}
         />
 
         <div className="setting-form-row">
@@ -243,7 +254,11 @@ export const LocalLLMSettings: React.FC<LocalLLMSettingsProps> = ({
               プロファイルがありません。「新規作成」から始めましょう。
             </div>
           )}
-          {profileList.map(p => {
+          {profileList.filter(p => {
+            const base = typeof p === 'string' ? null : p.base_model;
+            // Show profiles with no adapter yet (not yet trained) or trained on current model
+            return base == null || base === localModelName;
+          }).map(p => {
             const name = typeof p === 'string' ? p : p.name;
             const statusMessage = typeof p === 'string' ? 'データなし' : p.status_message;
             const needsTrain = typeof p === 'string' ? false : p.needs_train;

--- a/mise.toml
+++ b/mise.toml
@@ -11,7 +11,10 @@ run = "cd electron && pnpm build"
 
 [tasks.package]
 description = "Package as macOS DMG (unsigned)"
-run = "cd electron && pnpm build && npx electron-builder --mac --arm64 -c.mac.identity=null"
+run = """
+bash scripts/prepare_sidecar.sh
+cd electron && pnpm build && npx electron-builder --mac --arm64 -c.mac.identity=null
+"""
 
 [tasks.server]
 description = "Start Python server standalone (for debugging)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parcera"
-version = "0.5.0"
+version = "0.6.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/core/download.py
+++ b/src/core/download.py
@@ -79,11 +79,20 @@ def check_model_cached(model_name: str) -> bool:
             return False
     elif "/" in model_name:
         # Assume HuggingFace model (e.g. mlx-community/gemma-2-9b-it-4bit)
-        from huggingface_hub import try_to_load_from_cache
+        from huggingface_hub import scan_cache_dir
         try:
-            # Check for a specific file that should exist (e.g., config.json)
-            path = try_to_load_from_cache(model_name, filename="config.json")
-            return isinstance(path, str)
+            # Check for actual weight files, not just metadata (config.json can exist without weights)
+            cache_info = scan_cache_dir()
+            for repo in cache_info.repos:
+                if repo.repo_id == model_name:
+                    for revision in repo.revisions:
+                        has_weights = any(
+                            f.file_name.endswith(".safetensors")
+                            for f in revision.files
+                        )
+                        if has_weights:
+                            return True
+            return False
         except Exception:
             return False
     else:

--- a/src/core/local_llm.py
+++ b/src/core/local_llm.py
@@ -58,9 +58,16 @@ class LocalLLMService(LLMService):
         if not adapter_path:
             adapter_path = None
         if cls._model is None or cls._current_model_path != model_path or cls._current_adapter_path != adapter_path:
-            from mlx_lm import load
+            from mlx_lm.utils import load_model, load_tokenizer, load_adapters, _download
             logger.info(f"Loading MLX model: {model_path} (adapter: {adapter_path})...")
-            cls._model, cls._tokenizer = load(model_path, adapter_path=adapter_path)
+            # strict=False to allow VL models (e.g. Qwen3.5) to load without vision tower weights
+            resolved_path = _download(model_path)
+            model, config = load_model(resolved_path, lazy=False, strict=False)
+            if adapter_path:
+                model = load_adapters(model, adapter_path)
+                model.eval()
+            tokenizer = load_tokenizer(resolved_path, eos_token_ids=config.get("eos_token_id"))
+            cls._model, cls._tokenizer = model, tokenizer
             cls._current_model_path = model_path
             cls._current_adapter_path = adapter_path
             logger.info("MLX model loaded.")
@@ -140,7 +147,10 @@ class LocalLLMService(LLMService):
         import queue
 
         model, tokenizer = self._load_model(self.model, self.adapter_path)
-        prompt = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        template_kwargs = {"tokenize": False, "add_generation_prompt": True}
+        if self._model_family == "qwen":
+            template_kwargs["enable_thinking"] = False
+        prompt = tokenizer.apply_chat_template(messages, **template_kwargs)
         sampler = make_sampler(self.temperature)
 
         logger.debug(f"Local LLM: Starting threaded generation for context {context_id}")

--- a/src/core/local_llm.py
+++ b/src/core/local_llm.py
@@ -13,6 +13,10 @@ class LocalLLMService(LLMService):
     _current_model_path = None
     _current_adapter_path = None
 
+    _GEMMA_TAGS = ["<end_of_turn>", "<start_of_turn>", "<|end|>", "<|assistant|>", "<|user|>"]
+    _QWEN_TAGS = ["<|im_end|>", "<|im_start|>", "<|endoftext|>", "<think>", "</think>"]
+    SPECIAL_TAGS: List[str] = list(set(_GEMMA_TAGS + _QWEN_TAGS))
+
     @staticmethod
     def _detect_model_family(model_path: str) -> str:
         """Detect model family from model path string."""
@@ -43,6 +47,7 @@ class LocalLLMService(LLMService):
         )
         self.max_tokens = max_tokens
         self.adapter_path = adapter_path
+        self._model_family = self._detect_model_family(model)
 
     @property
     def dynamic_tool_name(self) -> str:
@@ -76,7 +81,6 @@ class LocalLLMService(LLMService):
 
     async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, Any] = None) -> List[Dict]:
         messages = []
-        family = self._detect_model_family(self.model)
         system_content = await self._get_system_prompt(context_id, user_id, system_prompt_params)
 
         if self.initial_messages:
@@ -86,7 +90,7 @@ class LocalLLMService(LLMService):
             context_id=[context_id] + self.shared_context_ids if self.shared_context_ids else [context_id]
         )
 
-        if family == "gemma":
+        if self._model_family == "gemma":
             # Gemma 2: system role unsupported — force histories to start with user
             while histories and histories[0]["role"] != "user":
                 histories.pop(0)
@@ -96,7 +100,7 @@ class LocalLLMService(LLMService):
         if text:
             messages.append({"role": "user", "content": text})
 
-        if family == "gemma":
+        if self._model_family == "gemma":
             # Embed system_content into first user message
             if messages and messages[0]["role"] == "user":
                 messages[0]["content"] = f"{system_content}\n\n{messages[0]['content']}"
@@ -111,8 +115,7 @@ class LocalLLMService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
-        family = self._detect_model_family(self.model)
-        assistant_role = "model" if family == "gemma" else "assistant"
+        assistant_role = "model" if self._model_family == "gemma" else "assistant"
 
         current_messages = list(messages)
         current_messages.append({"role": assistant_role, "content": response_text})
@@ -146,9 +149,7 @@ class LocalLLMService(LLMService):
 
         def producer():
             try:
-                # Use max_tokens from kwargs if provided, otherwise fallback to default
                 m_tokens = kwargs.get("max_tokens", self.max_tokens)
-                count = 0
                 for response in stream_generate(
                     model=model,
                     tokenizer=tokenizer,
@@ -157,9 +158,6 @@ class LocalLLMService(LLMService):
                     sampler=sampler
                 ):
                     q.put(response.text)
-                    count += 1
-                    if count >= m_tokens:
-                        break
                 q.put(None)  # Sentinel for end
             except Exception as e:
                 logger.error(f"Error in MLX generation thread: {e}")
@@ -168,21 +166,17 @@ class LocalLLMService(LLMService):
         # Run inference in a separate thread
         threading.Thread(target=producer, daemon=True).start()
 
-        GEMMA_TAGS = ["<end_of_turn>", "<start_of_turn>", "<|end|>", "<|assistant|>", "<|user|>"]
-        QWEN_TAGS = ["<|im_end|>", "<|im_start|>", "<|endoftext|>", "<think>", "</think>"]
-        SPECIAL_TAGS = list(set(GEMMA_TAGS + QWEN_TAGS))
-
         while True:
             # Yield control back to event loop while waiting for the next word
             word = await asyncio.to_thread(q.get)
-            
+
             if word is None:
                 break
             if isinstance(word, Exception):
                 raise word
 
             clean_text = word
-            for tag in SPECIAL_TAGS:
+            for tag in self.SPECIAL_TAGS:
                 clean_text = clean_text.replace(tag, "")
             
             if clean_text.strip() or clean_text == " ":

--- a/src/core/local_llm.py
+++ b/src/core/local_llm.py
@@ -111,10 +111,11 @@ class LocalLLMService(LLMService):
         return messages
 
     async def update_context(self, context_id: str, user_id: str, messages: List[Dict], response_text: str):
-        # Store in context manager. Gemma roles are user/model.
-        # We append the assistant response.
+        family = self._detect_model_family(self.model)
+        assistant_role = "model" if family == "gemma" else "assistant"
+
         current_messages = list(messages)
-        current_messages.append({"role": "model", "content": response_text})
+        current_messages.append({"role": assistant_role, "content": response_text})
         
         if self._update_context_filter:
             if current_messages and "content" in current_messages[-1]:

--- a/src/core/local_llm.py
+++ b/src/core/local_llm.py
@@ -13,6 +13,16 @@ class LocalLLMService(LLMService):
     _current_model_path = None
     _current_adapter_path = None
 
+    @staticmethod
+    def _detect_model_family(model_path: str) -> str:
+        """Detect model family from model path string."""
+        path_lower = model_path.lower()
+        if "qwen" in path_lower:
+            return "qwen"
+        if "gemma" in path_lower:
+            return "gemma"
+        return "unknown"
+
     def __init__(
         self,
         *,

--- a/src/core/local_llm.py
+++ b/src/core/local_llm.py
@@ -76,37 +76,37 @@ class LocalLLMService(LLMService):
 
     async def compose_messages(self, context_id: str, user_id: str, text: str, files: List[Dict[str, str]] = None, system_prompt_params: Dict[str, Any] = None) -> List[Dict]:
         messages = []
-        
-        # Add system prompt as a user message since Gemma 2 Instruct doesn't strictly have a system role in MLX template usually
-        # Or we can just prepend it to the first user message.
+        family = self._detect_model_family(self.model)
         system_content = await self._get_system_prompt(context_id, user_id, system_prompt_params)
-        
-        # Add initial messages
+
         if self.initial_messages:
             messages.extend(self.initial_messages)
 
-        # Get history
-        # histories are returned as list of dicts with role and content
         histories = await self.context_manager.get_histories(
             context_id=[context_id] + self.shared_context_ids if self.shared_context_ids else [context_id]
         )
-        
-        # Filter histories to start with a user message if necessary (Gemma requirement)
-        while histories and histories[0]["role"] != "user":
-            histories.pop(0)
-            
+
+        if family == "gemma":
+            # Gemma 2: system role unsupported — force histories to start with user
+            while histories and histories[0]["role"] != "user":
+                histories.pop(0)
+
         messages.extend(histories)
-        
-        # Add current message
+
         if text:
             messages.append({"role": "user", "content": text})
-            
-        # Re-insert system prompt if it's the first message or prepend it to the first user message
-        if messages and messages[0]["role"] == "user":
-            messages[0]["content"] = f"{system_content}\n\n{messages[0]['content']}"
-        elif system_content:
-            messages.insert(0, {"role": "user", "content": system_content})
-            messages.insert(1, {"role": "model", "content": "了解したわ！よろしくね。"})
+
+        if family == "gemma":
+            # Embed system_content into first user message
+            if messages and messages[0]["role"] == "user":
+                messages[0]["content"] = f"{system_content}\n\n{messages[0]['content']}"
+            elif system_content:
+                messages.insert(0, {"role": "user", "content": system_content})
+                messages.insert(1, {"role": "model", "content": "了解したわ！よろしくね。"})
+        else:
+            # Qwen / unknown: system role is natively supported
+            if system_content:
+                messages.insert(0, {"role": "system", "content": system_content})
 
         return messages
 

--- a/src/core/local_llm.py
+++ b/src/core/local_llm.py
@@ -168,8 +168,9 @@ class LocalLLMService(LLMService):
         # Run inference in a separate thread
         threading.Thread(target=producer, daemon=True).start()
 
-        # Gemma 2 specific tags to filter
-        SPECIAL_TAGS = ["<end_of_turn>", "<start_of_turn>", "<|end|>", "<|assistant|>", "<|user|>"]
+        GEMMA_TAGS = ["<end_of_turn>", "<start_of_turn>", "<|end|>", "<|assistant|>", "<|user|>"]
+        QWEN_TAGS = ["<|im_end|>", "<|im_start|>", "<|endoftext|>", "<think>", "</think>"]
+        SPECIAL_TAGS = list(set(GEMMA_TAGS + QWEN_TAGS))
 
         while True:
             # Yield control back to event loop while waiting for the next word

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -1,6 +1,9 @@
 import asyncio
 import logging
 import os
+
+# Suppress transformers "PyTorch was not found" warning (we use MLX, not PyTorch)
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
 from contextlib import asynccontextmanager
 from dotenv import load_dotenv
 from typing import Optional

--- a/src/services/training_service.py
+++ b/src/services/training_service.py
@@ -450,11 +450,22 @@ JSON形式のリストのみを出力してください。説明文等は一切�
             result = []
             for name in all_names:
                 stats = self._get_stats_sync(name)
+                # Read base_model from adapter_config.json if available
+                base_model = None
+                adapter_config_path = os.path.join(adapters_dir, name, "adapter_config.json")
+                if os.path.exists(adapter_config_path):
+                    try:
+                        with open(adapter_config_path) as f:
+                            adapter_cfg = json.load(f)
+                        base_model = adapter_cfg.get("model")
+                    except Exception:
+                        pass
                 result.append({
                     "name": name,
                     "status_message": stats["status_message"],
                     "total": stats["total"],
-                    "needs_train": stats["needs_train"]
+                    "needs_train": stats["needs_train"],
+                    "base_model": base_model,
                 })
             return result
 

--- a/src/services/training_service.py
+++ b/src/services/training_service.py
@@ -354,10 +354,11 @@ JSON形式のリストのみを出力してください。説明文等は一切�
                 content = p["edited_output"]
             
             if content:
-                # MLX / Llama-3 / Gemma-2 format
-                # Using Gemma-2 format as requested in TRD
                 formatted = {
-                    "text": f"<start_of_turn>user\n{p['input']}<end_of_turn>\n<start_of_turn>model\n{content}<end_of_turn>"
+                    "messages": [
+                        {"role": "user", "content": p["input"]},
+                        {"role": "assistant", "content": content}
+                    ]
                 }
                 train_data.append(formatted)
         

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -138,6 +138,35 @@ async def test_update_context_gemma_uses_model_role():
     assert saved_messages[-1]["role"] == "model"
 
 @pytest.mark.asyncio
+async def test_qwen_special_tags_are_filtered(mock_mlx):
+    """Qwen の特殊タグ (<|im_end|>, <think> 等) がストリームから除去されること。"""
+    mock_load, mock_stream, mock_model, mock_tokenizer = mock_mlx
+
+    mock_resp1 = MagicMock(); mock_resp1.text = "こんにちは"
+    mock_resp2 = MagicMock(); mock_resp2.text = "<|im_end|>"
+    mock_resp3 = MagicMock(); mock_resp3.text = "<think>考え中</think>"
+    mock_stream.return_value = iter([mock_resp1, mock_resp2, mock_resp3])
+
+    mock_cm = MagicMock()
+    mock_cm.get_context = AsyncMock(return_value=[])
+
+    service = LocalLLMService(
+        model="mlx-community/Qwen3.5-9B-MLX-4bit",
+        system_prompt="test",
+        context_manager=mock_cm
+    )
+
+    responses = []
+    async for chunk in service.get_llm_stream_response("ctx", "user", [{"role": "user", "content": "hi"}], None, None):
+        responses.append(chunk.text)
+
+    full_text = "".join(responses)
+    assert "<|im_end|>" not in full_text
+    assert "<think>" not in full_text
+    assert "</think>" not in full_text
+    assert "こんにちは" in full_text
+
+@pytest.mark.asyncio
 async def test_local_llm_service_cache_behavior(mock_mlx):
     mock_load, _, _, _ = mock_mlx
     

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -53,6 +53,17 @@ async def test_local_llm_service_inference(mock_mlx):
     # Verify stream_generate calls
     assert mock_stream.call_count == 1
 
+def test_detect_model_family_qwen():
+    assert LocalLLMService._detect_model_family("mlx-community/Qwen3.5-9B-MLX-4bit") == "qwen"
+    assert LocalLLMService._detect_model_family("Qwen/Qwen3.5-4B") == "qwen"
+
+def test_detect_model_family_gemma():
+    assert LocalLLMService._detect_model_family("mlx-community/gemma-2-9b-it-4bit") == "gemma"
+    assert LocalLLMService._detect_model_family("google/gemma-2-2b-it") == "gemma"
+
+def test_detect_model_family_unknown():
+    assert LocalLLMService._detect_model_family("some-other-model/llama-3") == "unknown"
+
 @pytest.mark.asyncio
 async def test_local_llm_service_cache_behavior(mock_mlx):
     mock_load, _, _, _ = mock_mlx

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -5,24 +5,22 @@ from src.core.local_llm import LocalLLMService
 
 @pytest.fixture
 def mock_mlx():
-    with patch("mlx_lm.load") as mock_load, \
+    mock_model = MagicMock()
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.apply_chat_template.return_value = "formatted_prompt"
+
+    # Mock GenerationResponse object
+    mock_resp1 = MagicMock()
+    mock_resp1.text = "Hello"
+    mock_resp2 = MagicMock()
+    mock_resp2.text = " world"
+
+    with patch("src.core.local_llm.LocalLLMService._load_model", return_value=(mock_model, mock_tokenizer)) as mock_load, \
          patch("mlx_lm.generate.stream_generate") as mock_stream:
-        
-        mock_model = MagicMock()
-        mock_tokenizer = MagicMock()
-        mock_tokenizer.apply_chat_template.return_value = "formatted_prompt"
-        
-        mock_load.return_value = (mock_model, mock_tokenizer)
-        
-        # Mock GenerationResponse object
-        mock_resp1 = MagicMock()
-        mock_resp1.text = "Hello"
-        mock_resp2 = MagicMock()
-        mock_resp2.text = " world"
-        
+
         # Mock stream_generate yields GenerationResponse objects
         mock_stream.return_value = iter([mock_resp1, mock_resp2])
-        
+
         yield mock_load, mock_stream, mock_model, mock_tokenizer
 
 @pytest.mark.asyncio
@@ -44,8 +42,8 @@ async def test_local_llm_service_inference(mock_mlx):
     text_chunks = [r.text for r in responses if hasattr(r, 'text')]
     assert text_chunks == ["Hello", " world"]
     
-    # Verify model loading
-    mock_load.assert_called_once_with("test_model", adapter_path=None)
+    # Verify _load_model was called
+    mock_load.assert_called_once()
     
     # Verify prompt formatting
     mock_tokenizer.apply_chat_template.assert_called_once()
@@ -167,22 +165,34 @@ async def test_qwen_special_tags_are_filtered(mock_mlx):
     assert "こんにちは" in full_text
 
 @pytest.mark.asyncio
-async def test_local_llm_service_cache_behavior(mock_mlx):
-    mock_load, _, _, _ = mock_mlx
-    
-    mock_cm = MagicMock()
-    mock_cm.get_context = AsyncMock(return_value=[])
-    
-    service = LocalLLMService(model="model_a", system_prompt="test", context_manager=mock_cm)
-    
-    # First call loads model_a
-    service._load_model("model_a", None)
-    assert mock_load.call_count == 1
-    
-    # Second call with same model name uses cache
-    service._load_model("model_a", None)
-    assert mock_load.call_count == 1
-    
-    # Call with different model name triggers reload
-    service._load_model("model_b", None)
-    assert mock_load.call_count == 2
+async def test_local_llm_service_cache_behavior():
+    """_load_model caches the model for the same path and reloads for a different path."""
+    mock_model = MagicMock()
+    mock_tokenizer = MagicMock()
+    mock_config = MagicMock()
+    mock_config.get.return_value = None
+
+    with patch("mlx_lm.utils.load_model", return_value=(mock_model, mock_config)) as mock_lm, \
+         patch("mlx_lm.utils.load_tokenizer", return_value=mock_tokenizer), \
+         patch("mlx_lm.utils._download", side_effect=lambda p: p):
+        # Reset class-level cache before test
+        LocalLLMService._model = None
+        LocalLLMService._current_model_path = None
+        LocalLLMService._current_adapter_path = None
+
+        # First call loads model_a
+        LocalLLMService._load_model("model_a", None)
+        assert mock_lm.call_count == 1
+
+        # Second call with same model name uses cache
+        LocalLLMService._load_model("model_a", None)
+        assert mock_lm.call_count == 1
+
+        # Call with different model name triggers reload
+        LocalLLMService._load_model("model_b", None)
+        assert mock_lm.call_count == 2
+
+        # Reset cache after test
+        LocalLLMService._model = None
+        LocalLLMService._current_model_path = None
+        LocalLLMService._current_adapter_path = None

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -100,6 +100,44 @@ async def test_compose_messages_gemma_embeds_system_in_user():
     assert "こんにちは" in messages[0]["content"]
 
 @pytest.mark.asyncio
+async def test_update_context_qwen_uses_assistant_role():
+    """Qwen では context に "assistant" ロールで保存されること。"""
+    mock_cm = MagicMock()
+    mock_cm.add_histories = AsyncMock()
+    mock_cm.get_histories = AsyncMock(return_value=[])
+
+    service = LocalLLMService(
+        model="mlx-community/Qwen3.5-9B-MLX-4bit",
+        system_prompt="test",
+        context_manager=mock_cm
+    )
+    messages = [{"role": "user", "content": "hi"}]
+    await service.update_context("ctx", "user1", messages, "hello!")
+
+    call_args = mock_cm.add_histories.call_args
+    saved_messages = call_args[0][1]
+    assert saved_messages[-1]["role"] == "assistant"
+
+@pytest.mark.asyncio
+async def test_update_context_gemma_uses_model_role():
+    """Gemma では context に "model" ロールで保存されること。"""
+    mock_cm = MagicMock()
+    mock_cm.add_histories = AsyncMock()
+    mock_cm.get_histories = AsyncMock(return_value=[])
+
+    service = LocalLLMService(
+        model="mlx-community/gemma-2-9b-it-4bit",
+        system_prompt="test",
+        context_manager=mock_cm
+    )
+    messages = [{"role": "user", "content": "hi"}]
+    await service.update_context("ctx", "user1", messages, "hello!")
+
+    call_args = mock_cm.add_histories.call_args
+    saved_messages = call_args[0][1]
+    assert saved_messages[-1]["role"] == "model"
+
+@pytest.mark.asyncio
 async def test_local_llm_service_cache_behavior(mock_mlx):
     mock_load, _, _, _ = mock_mlx
     

--- a/tests/test_local_llm.py
+++ b/tests/test_local_llm.py
@@ -65,6 +65,41 @@ def test_detect_model_family_unknown():
     assert LocalLLMService._detect_model_family("some-other-model/llama-3") == "unknown"
 
 @pytest.mark.asyncio
+async def test_compose_messages_qwen_uses_system_role():
+    """Qwen は system role を正式サポート。system_content が {"role": "system"} として先頭に入ること。"""
+    mock_cm = MagicMock()
+    mock_cm.get_histories = AsyncMock(return_value=[])
+
+    service = LocalLLMService(
+        model="mlx-community/Qwen3.5-9B-MLX-4bit",
+        system_prompt="You are a helpful AI.",
+        context_manager=mock_cm
+    )
+    messages = await service.compose_messages("ctx", "user1", "こんにちは")
+
+    assert messages[0]["role"] == "system"
+    assert "You are a helpful AI." in messages[0]["content"]
+    assert messages[1]["role"] == "user"
+    assert messages[1]["content"] == "こんにちは"
+
+@pytest.mark.asyncio
+async def test_compose_messages_gemma_embeds_system_in_user():
+    """Gemma は system role 非サポート。system_content が user メッセージに埋め込まれること。"""
+    mock_cm = MagicMock()
+    mock_cm.get_histories = AsyncMock(return_value=[])
+
+    service = LocalLLMService(
+        model="mlx-community/gemma-2-9b-it-4bit",
+        system_prompt="You are a helpful AI.",
+        context_manager=mock_cm
+    )
+    messages = await service.compose_messages("ctx", "user1", "こんにちは")
+
+    assert messages[0]["role"] == "user"
+    assert "You are a helpful AI." in messages[0]["content"]
+    assert "こんにちは" in messages[0]["content"]
+
+@pytest.mark.asyncio
 async def test_local_llm_service_cache_behavior(mock_mlx):
     mock_load, _, _, _ = mock_mlx
     

--- a/tests/test_training_service.py
+++ b/tests/test_training_service.py
@@ -143,3 +143,33 @@ async def test_calculate_merge_weights(mock_config):
     weights = service._calculate_merge_weights(configs)
     assert weights["Main"] == 0.5
     assert weights["Exp1"] == 0.3
+
+@pytest.mark.asyncio
+async def test_export_to_jsonl_uses_messages_format(mock_config, mock_gemini, tmp_path):
+    """export_to_jsonl が messages 形式を出力すること（Gemma 固定フォーマットではない）。"""
+    import json
+    mock_config.app_data_dir = str(tmp_path)
+    service = TrainingService(mock_config, teacher_llm=mock_gemini)
+    await service.add_knowledge_from_text("test knowledge")
+
+    pairs = await service.get_pairs()
+    await service.update_pair(pairs[0]["id"], status="ok")
+
+    export_path = str(tmp_path / "test_export.jsonl")
+    count = await service.export_to_jsonl(export_path)
+
+    assert count == 1
+
+    with open(export_path, "r") as f:
+        line = json.loads(f.readline())
+
+    # messages 形式であること
+    assert "messages" in line
+    assert isinstance(line["messages"], list)
+    assert line["messages"][0]["role"] == "user"
+    assert line["messages"][1]["role"] == "assistant"
+
+    # Gemma 固定フォーマットの残骸がないこと
+    assert "text" not in line
+    assert "<start_of_turn>" not in str(line)
+    assert "<end_of_turn>" not in str(line)

--- a/uv.lock
+++ b/uv.lock
@@ -1474,7 +1474,7 @@ wheels = [
 
 [[package]]
 name = "parcera"
-version = "0.5.0"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiavatar" },


### PR DESCRIPTION
## Overview

ローカル LLM として Gemma 2 のみだった対応モデルを拡張し、**Qwen3.5 (4B / 9B)** を選択可能にした。Qwen3.5 は VL（Vision-Language）モデルで `strict=False` によるテキスト専用ロードが必要であり、かつ Gemma とはプロンプト形式・ロール名・特殊トークンが異なるため、モデルファミリー検出ロジックを実装してすべての差異を吸収する。

あわせて、LoRA アダプターのアーキテクチャ不一致（Gemma 用アダプターを Qwen に適用してしまう問題）を UI 側のフィルタリングとモデル切り替え時の自動クリアで防止した。

## Changes

### Backend (`src/core/local_llm.py`)
- `_detect_model_family(model_path)`: モデルパス文字列から `"gemma"` / `"qwen"` / `"unknown"` を判定する static method を追加
- `_GEMMA_TAGS` / `_QWEN_TAGS` をクラス定数として分離し `SPECIAL_TAGS` に統合（`<|im_end|>`, `<|im_start|>`, `<think>`, `</think>` を追加）
- `compose_messages`: Gemma はシステムプロンプトを最初の user メッセージに埋め込む従来挙動を維持、Qwen は `{"role": "system", ...}` でネイティブ渡し
- `update_context`: Gemma は `"model"` ロール、Qwen は `"assistant"` ロールで履歴を保存
- `_load_model`: `mlx_lm.load()` から `load_model(strict=False)` + `load_adapters()` の低レベル API 呼び出しに変更。Qwen3.5（VL モデル）の vision tower 重みを無視してテキスト部分のみロード可能に
- `apply_chat_template`: Qwen に対して `enable_thinking=False` を渡し、推論過程の出力（thinking モード）を無効化

### Backend (`src/services/training_service.py`)
- `_get_profiles_sync`: 各プロファイルの `adapter_config.json` から `base_model` を読み取り、API レスポンスに含める
- `export_to_jsonl`: Gemma 専用の `<start_of_turn>` フォーマットから `{"messages": [...]}` 形式に変更し、モデル非依存に

### Backend (`src/core/download.py`)
- `check_model_cached` (HuggingFace モデル): `config.json` の存在確認から `scan_cache_dir()` による `.safetensors` 重みファイルの存在確認に変更。メタデータのみキャッシュされている場合の誤判定を修正

### Frontend (`electron/renderer/components/settings/LocalLLMSettings.tsx`)
- モデル選択をテキスト入力から `SelectSetting` ドロップダウンに変更（Gemma 2 9B / Qwen3.5 9B / Qwen3.5 4B の 3 プリセット）
- モデル切り替え時に `adapter_path` を自動クリア + ブレンド重みをリセット（アーキテクチャ不一致エラーの防止）
- LoRA プロファイルリストを `base_model` フィールドでフィルタリング：選択中モデルと互換性があるもの、または未学習（`base_model: null`）のみ表示

## Verification

```
87 passed, 3 warnings in 7.70s
```

- `test_detect_model_family_*`: 3ケース（qwen / gemma / unknown）全パス
- `test_compose_messages_*`: Qwen system role / Gemma user 埋め込み両方パス
- `test_update_context_*`: ロール名の family-aware 切り替えパス
- `test_qwen_special_tags_are_filtered`: 特殊トークンフィルタパス
- `test_export_to_jsonl_uses_messages_format`: messages 形式パス
- `test_local_llm_service_cache_behavior`: キャッシュ挙動パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)