### PR TITLE
feat: OBS Browser Source support & runtime settings hot-reload (v0.14.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ cython_debug/
 # Tauri Rust build artifacts
 src-tauri/target/
 src-tauri/WixTools/
+
+# Build distribution artifacts (DMG, .app)
+releases/

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,1 +1,2 @@
 /cache
+/logs

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,24 +3,26 @@ project_name: "parcera"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  ansible             bash                clojure             cpp
-#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
-#   elixir              elm                 erlang              fortran             fsharp
-#   go                  groovy              haskell             haxe                hlsl
-#   java                json                julia               kotlin              lean4
-#   lua                 luau                markdown            matlab              msl
-#   nix                 ocaml               pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         python_ty
-#   r                   rego                ruby                ruby_solargraph     rust
-#   scala               solidity            swift               systemverilog       terraform
-#   toml                typescript          typescript_vts      vue                 yaml
-#   zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -125,3 +127,14 @@ ls_specific_settings: {}
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-05-06 - OBS Browser Source
+
+### Added
+- **OBS Browser Source support**: Standalone `obs.html` served as `file://` URI so OBS can load the avatar page before Parcera's HTTP server starts; JS retries WebSocket connection automatically on Parcera restart — no manual OBS refresh needed
+- **AI avatar lipsync in OBS**: WebAudio `AnalyserNode` decodes TTS audio chunks received via WebSocket; spectral-centroid vowel detection (`getAIVowel`) drives mouth animation for all five Japanese vowels (u/o/a/e/i)
+- **Python avatar asset proxy**: `GET /config/obs-asset/{type}/{filename}` serves sprite images through FastAPI, bypassing `file://` mixed-content restrictions; resolves configured `assets_dir` with fallback to bundled assets
+- **`file://` URL display in settings UI**: Settings screen fetches `GET /config/obs-html-path` and shows a clickable `file://` URL for each OBS browser source, ready to paste into OBS without running Parcera first
+- **SVG chroma key filter for OBS**: `feColorMatrix` + `feComponentTransfer` filter applied via CSS class to avatar image; matches the Tauri window chroma key implementation; supports green and blue key colors
+- **`flip_horizontal` support in OBS**: Avatar image mirrored via `scaleX(-1)` in the per-frame transform, composing correctly with breathing and lip-sync transforms
+- **Asset cache-busting**: `?v={timestamp}` appended to all asset URLs on each `applySettings` call, ensuring custom avatar changes reflect immediately without OBS restart
+
+### Fixed
+- **Asset 404 in OBS**: `settings.default.yaml` stores Tauri virtual paths (e.g. `/assets/user`) that do not exist on the filesystem; asset proxy now checks `Path.is_dir()` before trusting the configured path and falls back to bundled assets
+- **AI avatar mouthing user mic audio**: OBS `obs.html` was driving the AI avatar with `user_lipsync` WebSocket events regardless of `avatarType`; branched WS message handler and animation loop by type
+- **Spectral vowel detection regression**: Initial OBS AI lipsync used only RMS amplitude (open/close); full spectral-centroid algorithm ported from `audio.ts`, matching Tauri window quality
+- **Custom assets not reflected in OBS**: Browser cache prevented proxy URL changes from taking effect; fixed with per-reload `?v={Date.now()}` cache key
+- **Chroma key showing green background**: Incorrect approach set `document.body.style.background` to the key color (opaque); reverted to CSS SVG filter that makes matched pixels transparent, matching Tauri behavior
+
+### Changed
+- **Build output separation**: Vite web output moved to `dist/web/`; DMG and `.app` bundles copied to `releases/` (gitignored); `emptyOutDir: true` no longer wipes previous release artifacts on each build
+
 ## [0.13.0] - 2026-05-05 - Gemma 4 & Multi-Model MLX Support
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.14.0] - 2026-05-06 - OBS Browser Source
+## [0.14.0] - 2026-05-07 - OBS Browser Source & Runtime Settings
 
 ### Added
 - **OBS Browser Source support**: Standalone `obs.html` served as `file://` URI so OBS can load the avatar page before Parcera's HTTP server starts; JS retries WebSocket connection automatically on Parcera restart — no manual OBS refresh needed
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **SVG chroma key filter for OBS**: `feColorMatrix` + `feComponentTransfer` filter applied via CSS class to avatar image; matches the Tauri window chroma key implementation; supports green and blue key colors
 - **`flip_horizontal` support in OBS**: Avatar image mirrored via `scaleX(-1)` in the per-frame transform, composing correctly with breathing and lip-sync transforms
 - **Asset cache-busting**: `?v={timestamp}` appended to all asset URLs on each `applySettings` call, ensuring custom avatar changes reflect immediately without OBS restart
+- **Python `MicAnalyzer`**: `sounddevice`-based capture runs from startup; broadcasts `user_lipsync` WebSocket events (amplitude + vowel + speaking flag) to all clients; feeds speech chunks to STT via energy-based VAD
+- **OBS User avatar lipsync via WebSocket**: User window in OBS mode subscribes to `user_lipsync` events from `MicAnalyzer` instead of running `getUserMedia`, removing the browser permission requirement
+- **Avatar window visibility toggle**: "アバターウィンドウを表示する" switch in Character Settings; when OFF, position/lock/size controls are disabled; changes applied to the Tauri window on save
+- **`alwaysOnTop` runtime control**: `set_window_always_on_top` Tauri command applies window always-on-top state immediately on save and restores it on startup
+- **Instant hot-reload for more settings**: VAD `silence_duration_threshold`, `max_duration`; STS `merge_request_threshold`; mic device (restarts `MicAnalyzer` on change); LLM model and temperature within the same provider — all take effect on save without restart
+- **"要再起動" badges on settings labels**: Muted small badges mark settings that still require a restart (STT provider/model/device/quantization, TTS provider, port, GPU acceleration)
+- **Contextual save message**: Save button shows "一部の変更は再起動後に反映されます" (8 s) when the Python reload endpoint signals `restart_required: true`, otherwise shows the standard confirmation (3 s)
+- **`tauri-plugin-localhost`**: Frontend served on a dedicated `frontend_port` (default 8677) separate from the Python backend port (8676); enables reliable OBS HTTP-mode loading
 
 ### Fixed
 - **Asset 404 in OBS**: `settings.default.yaml` stores Tauri virtual paths (e.g. `/assets/user`) that do not exist on the filesystem; asset proxy now checks `Path.is_dir()` before trusting the configured path and falls back to bundled assets
@@ -22,9 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Spectral vowel detection regression**: Initial OBS AI lipsync used only RMS amplitude (open/close); full spectral-centroid algorithm ported from `audio.ts`, matching Tauri window quality
 - **Custom assets not reflected in OBS**: Browser cache prevented proxy URL changes from taking effect; fixed with per-reload `?v={Date.now()}` cache key
 - **Chroma key showing green background**: Incorrect approach set `document.body.style.background` to the key color (opaque); reverted to CSS SVG filter that makes matched pixels transparent, matching Tauri behavior
+- **Double USER log per utterance**: `on_recognized_callback` was assigned redundantly; when `MicAnalyzer` called `stt.recognize()` the STT fired the callback internally, then `_handle_stt_audio` also called `controller.on_recognized()`, logging every utterance twice
+- **MicAnalyzer early flush losing next utterance**: VAD early flush (after `MAX_SPEECH_CHUNKS`) cleared buffer and count but left `_is_speaking=True`; the next silence chunk immediately entered the post-speech handler against a zero-length buffer, silently discarding trailing audio
+- **`merge_request_threshold` default mismatch**: Constructor used `3.0` s as fallback while `apply_runtime_config` used `0.6` s (matching `settings.default.yaml`); now consistently `0.6` s
+- **Credential leak via OBS settings endpoint**: `GET /config/settings` returned the full raw settings dict including LLM/STT/TTS API keys and Twitch `client_secret`; credentials are now stripped before the response is sent
 
 ### Changed
 - **Build output separation**: Vite web output moved to `dist/web/`; DMG and `.app` bundles copied to `releases/` (gitignored); `emptyOutDir: true` no longer wipes previous release artifacts on each build
+- **`alwaysOnTop` setting now applied at runtime**: Previously saved to YAML but never acted upon; now applied via Tauri command on save and restored on startup
 
 ## [0.13.0] - 2026-05-05 - Gemma 4 & Multi-Model MLX Support
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-05-19 - Post-release Stabilization
+
+### Fixed
+- **Settings reload decoupled from save**: Python hot-reload no longer blocks save response; save button no longer stays stuck on "保存中" after mic device changes
+- **`update_setting` made non-blocking**: Timer cleanup added to prevent dangling async tasks on rapid setting changes
+- **Save status no longer sticks**: UI correctly resets save button state after both successful and failed reloads; window-op errors are now logged
+- **Tauri window commands**: Fixed camelCase key mismatch (`windowLabel` → `label` etc.) in IPC bridge calls for `set_window_always_on_top`, `show_window`, `hide_window`
+- **mypy type annotations in `MicAnalyzer`**: `_stream` typed as `Optional[Any]`, callbacks narrowed from `Awaitable[None]` to `Coroutine[Any, Any, None]`; `sounddevice` lazy-import suppressed with `type: ignore[import-untyped]`
+- **`mypy.ini`**: Added `sounddevice` to ignore list via inline suppression
+
 ## [0.14.0] - 2026-05-07 - OBS Browser Source & Runtime Settings
 
 ### Added

--- a/configs/settings.default.yaml
+++ b/configs/settings.default.yaml
@@ -129,6 +129,7 @@ vad:
 # ==========================================
 app:
   port: 8676 # WebSocket Server Port. Changing this requires an app restart.
+  frontend_port: 8677 # HTTP port for tauri-plugin-localhost (OBS Browser Source). Must be port + 1.
   ai_audio_sample_rate: 16000  # [Hz] Must match TTS engine output sample rate used in Python.
   gpu_acceleration: true # [Boolean] Set false to fix OBS window capture animation freeze on macOS.
   mic_device_id: "default" # "default" or specific media device ID

--- a/configs/settings.default.yaml
+++ b/configs/settings.default.yaml
@@ -135,6 +135,7 @@ app:
   mic_device_id: "default" # "default" or specific media device ID
   windows:
     ai:
+      visible: true
       width: 400
       height: 400
       x: 400
@@ -143,6 +144,7 @@ app:
       locked: false
       control_corner: "bottom-right"
     user:
+      visible: true
       width: 400
       height: 400
       x: 0

--- a/docs/specs/obs-browser-source/PRD.md
+++ b/docs/specs/obs-browser-source/PRD.md
@@ -1,0 +1,27 @@
+# OBS Browser Source 対応 PRD
+
+## 1. 目的
+
+OBS の「ブラウザソース（Browser Source）」として Parcera のアバターを直接読み込み、ウィンドウキャプチャ不要でシームレスに配信に組み込む。
+
+## 2. ユーザー体験
+
+- 設定画面の「OBS Browser Source URL」から `file://` URI をコピーするだけで OBS に追加できる
+- **OBS を先に起動してから Parcera を起動しても正常に動作する**（`file://` 読み込みのため）
+- Parcera を再起動しても OBS 側での手動更新は不要（WS が自動再接続する）
+- AI アバターの口パクアニメが OBS 上でリアルタイムに動作する
+- ユーザーアバターも OBS Browser Source として追加でき、Python のマイク解析と同期して口パクが動く
+- カスタムアバターの変更・クロマキー設定が OBS 側に即座に反映される
+
+## 3. スコープ
+
+### 今回含む
+- AI アバター OBS Browser Source 対応（TTS 音声受信 + 口パク）
+- ユーザーアバター OBS Browser Source 対応（Python マイク解析による口パク）
+- Python による直接マイク収音・STT 収音の一本化
+- アバタースプライトの HTTP プロキシ配信
+- クロマキー・フリップ水平対称の OBS 適用
+
+### 含まない
+- OBS カスタムブラウザドック（設定 UI の OBS 埋め込み）
+- Tauri アバターウィンドウの OBS モード時自動非表示

--- a/docs/specs/obs-browser-source/TRD.md
+++ b/docs/specs/obs-browser-source/TRD.md
@@ -1,0 +1,142 @@
+# OBS Browser Source 対応 TRD
+
+## 1. アーキテクチャ概要
+
+```
+Tauri アプリ（起動中）
+  ├── tauri-plugin-localhost → フロントエンドを HTTP 配信（ポート 8677）
+  └── Python サイドカー（ポート 8676）
+        ├── sounddevice でマイク直接収音
+        ├── STT パイプライン（既存 STT エンジンへバッファを渡す）
+        ├── 振幅 + スペクトル重心母音解析 → WS broadcast（user_lipsync）
+        └── FastAPI
+              ├── WS /ws                      ← TTS 音声 + AI lipsync
+              ├── GET /config/obs.html        ← obs.html をサーブ
+              ├── GET /config/obs-html-path   ← file:// URI を返す
+              ├── GET /config/obs-asset/{type}/{file} ← スプライト画像プロキシ
+              └── GET /config/settings        ← 設定 JSON（OBS 用）
+
+OBS
+  ├── Browser Source: file:///...obs.html?type=ai
+  │     └── JS 内蔵 WS 再接続ループ → ws://127.0.0.1:8676/ws
+  │         → TTS 音声受信（WebAudio）+ スペクトル重心母音解析 → 口パク
+  └── Browser Source: file:///...obs.html?type=user
+        └── JS 内蔵 WS 再接続ループ → ws://127.0.0.1:8676/ws
+            → user_lipsync イベント受信 → 口パク描画
+```
+
+### file:// アプローチの理由
+
+従来案（`http://localhost:{FRONTEND_PORT}/?obs=1`）に対して `file://` URI を一次 URL とした理由：
+
+- OBS を先に起動してから Parcera を起動するワークフローに対応できる
+- HTTP サーバー起動前でも `file://` からページが即座に読み込まれ、JS の WS 再接続ループが始まる
+- Parcera 再起動時も OBS 側の手動更新が不要
+
+## 2. コンポーネント別設計
+
+### 2-1. standalone `obs.html`
+
+**目的**: OBS Browser Source 専用の自己完結 HTML ページ。`file://` 読み込みでも動作する。
+
+- `src/static/obs.html`（カノニカル） / `ui/public/obs.html`（Tauri 配信コピー）として管理
+- `ui/vite.config.ts` の `syncObsHtml` プラグインがビルド時に自動同期
+- ビルドツール不使用（インライン JS / CSS / vanilla）
+- ポート解決: `window.location.port` から `pythonPort` を導出（`file://` の場合は NaN → デフォルト 8676）
+
+**AI アバター**: WebAudio `AnalyserNode` で受信 TTS 音声を解析し、スペクトル重心母音検出で口パク
+
+**User アバター**: WS `user_lipsync` イベントを購読してスプライトを切り替え
+
+**再起動耐性**: 内蔵の WS 再接続ループ（指数バックオフ）が Parcera の起動・再起動を検出して自動再接続
+
+### 2-2. フロントエンド HTTP 配信（`tauri-plugin-localhost`）
+
+React フロントエンドの Tauri 埋め込みアセットを HTTP 公開するために使用。
+
+- ポート: `settings.app.frontend_port`（デフォルト 8677 = python_port + 1）
+- `src-tauri/Cargo.toml` に `tauri-plugin-localhost = "2"` 追加
+- `src-tauri/src/lib.rs` でポートを設定から読んで起動
+- `src-tauri/capabilities/default.json` に `localhost:default` 追加
+
+### 2-3. Python マイク直接収音（`MicAnalyzer`）
+
+**ファイル**: `src/core/mic_analyzer.py`
+
+`sounddevice` でマイク音声をコールバック方式で収音し、2つの役割を果たす：
+
+1. **lipsync ブロードキャスト**: 各フレームで RMS + スペクトル重心 → 母音判定し WS 全クライアントへ送信
+2. **STT VAD**: エネルギーベース VAD で発話区間を検出し STT パイプラインへ渡す
+
+```json
+// user_lipsync イベント形式
+{"type": "user_lipsync", "vowel": "a", "amplitude": 0.72, "speaking": true}
+```
+
+**VAD パラメータ**:
+- `SILENCE_CHUNKS_TO_FLUSH = 15`（約 480ms の無音でフラッシュ）
+- `MIN_SPEECH_CHUNKS = 5`（約 160ms 未満の短い音は棄却）
+- `MAX_SPEECH_CHUNKS = 300`（約 9.6s でバッファを強制フラッシュ）
+
+**母音検出**: スペクトル重心（Hz）で分類。`audio.ts` の `VOWEL_BOUNDARIES_HZ` と同じ閾値を使用。
+
+### 2-4. アセットプロキシ（`GET /config/obs-asset/{type}/{filename}`）
+
+`obs.html` が `http://` で配信されるため、`file://` のスプライト画像を直接読み込むと Chromium の mixed-content ポリシーでブロックされる。FastAPI がプロキシとして中継する。
+
+- `avatar_type` は `{"user", "ai"}` に限定（パストラバーサル防止）
+- `assets_dir` は設定値が実在するディレクトリか確認してから使用（Tauri 仮想パス除外）
+- 実在しない場合はバンドル済みアセットにフォールバック
+
+### 2-5. 設定エンドポイント（`GET /config/settings`）
+
+OBS Browser Source は Tauri IPC を使えないため、Python 経由で設定 JSON を取得する。
+
+`src/routers/config_router.py` に追加（既存 `/config/reload` と同じルーター）。
+
+### 2-6. OBS URL の設定画面表示
+
+`ui/renderer/components/sections/AdvancedSection.tsx` で `GET /config/obs-html-path` を呼び出し、`file://` URI を優先表示。Parcera が未起動の場合は HTTP フォールバック URL を表示。
+
+```
+OBS Browser Source URL
+AI アバター:   file:///...obs.html?type=ai   [コピー]
+User アバター: file:///...obs.html?type=user  [コピー]
+```
+
+### 2-7. フロントエンド lipsync 購読（Tauri React アプリ）
+
+`ui/renderer/lib/comm.ts` の `startLipsyncWebSocket()` が WS `user_lipsync` イベントを購読し、`audio.ts` の `setExternalLipsync()` を呼び出して `visual.ts` に渡す。
+
+- Tauri の User アバターウィンドウ・OBS User アバターの両方が使用
+- WS 切断時に `clearExternalLipsync()` を呼び出し口パクをリセット
+
+## 3. 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `src/static/obs.html` | 新規: OBS Browser Source 専用スタンドアロンページ |
+| `ui/public/obs.html` | 同上（Tauri 配信コピー。ビルド時自動同期） |
+| `src/core/mic_analyzer.py` | 新規: sounddevice 収音 + 振幅/母音解析 + WS broadcast + STT VAD |
+| `src/routers/config_router.py` | 追加: `GET /config/obs.html`, `/obs-html-path`, `/obs-asset/`, `/settings` |
+| `src/run_server.py` | 追加: MicAnalyzer 起動・停止管理、STT → STS パイプライン連携 |
+| `ui/renderer/lib/obs-bridge.ts` | 新規: OBS 用 API ブリッジ（HTTP による設定取得・更新） |
+| `ui/renderer/lib/api.ts` | 追加: `?obs=1` 検出で obs-bridge へルーティング |
+| `ui/renderer/lib/audio.ts` | 追加: `setExternalLipsync` / `clearExternalLipsync` / `getExternalLipsync` |
+| `ui/renderer/lib/comm.ts` | 追加: `startLipsyncWebSocket()`, `startObsServerWatcher()` |
+| `ui/renderer/lib/visual.ts` | 追加: external lipsync 優先ロジック |
+| `ui/renderer/lib/hooks/useAvatar.ts` | 変更: OBS モード分岐（getUserMedia スキップ、WS lipsync 購読） |
+| `ui/renderer/components/sections/AdvancedSection.tsx` | 追加: OBS URL 表示 UI |
+| `configs/settings.default.yaml` | 追加: `app.frontend_port: 8677` |
+| `src-tauri/Cargo.toml` | 追加: `tauri-plugin-localhost = "2"` |
+| `src-tauri/src/settings_store.rs` | 追加: `get_frontend_port()` |
+| `src-tauri/src/lib.rs` | 追加: localhost プラグイン登録・frontend_port 読み込み |
+| `ui/vite.config.ts` | 追加: `syncObsHtml` プラグイン（obs.html 自動同期） |
+
+## 4. 制約・注意点
+
+- `tauri-plugin-localhost` ポート（8677）と Python ポート（8676）は別。`obs.html` は常に Python ポートへ接続
+- `sounddevice` は macOS で `portaudio` バインディングを使用
+- マイクデバイス選択は既存の `settings.app.mic_device_id` を Python 側でも参照
+- OBS Browser Source の WS は同一ホスト `127.0.0.1` のため CORS 不要
+- アセットキャッシュ: `applySettings` 呼び出しごとに `?v={timestamp}` でキャッシュバスト

--- a/mise.toml
+++ b/mise.toml
@@ -10,14 +10,14 @@ env = { RUST_LOG = "info" }
 run = "ui/node_modules/.bin/tauri dev --config src-tauri/tauri.dev.conf.json"
 
 [tasks.build]
-description = "Build Tauri app (production) and copy DMG/app to dist/"
+description = "Build Tauri app (production) and copy DMG/app to releases/"
 run = """
 ui/node_modules/.bin/tauri build
-mkdir -p dist
-cp src-tauri/target/release/bundle/dmg/*.dmg dist/ 2>/dev/null || true
-cp -r "src-tauri/target/release/bundle/macos/Parcera.app" dist/ 2>/dev/null || true
-echo "Build artifacts copied to dist/"
-ls dist/
+mkdir -p releases
+cp src-tauri/target/release/bundle/dmg/*.dmg releases/ 2>/dev/null || true
+cp -r "src-tauri/target/release/bundle/macos/Parcera.app" releases/ 2>/dev/null || true
+echo "Build artifacts copied to releases/"
+ls releases/
 """
 
 [tasks.package]

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,3 +22,4 @@ ignore_missing_imports = True
 
 [mypy-dotenv.*]
 ignore_missing_imports = True
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parcera"
-version = "0.13.0"
+version = "0.14.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "pydantic>=2.13.3",
   "mlx-lm>=0.31.3 ; sys_platform == 'darwin'",
   "beautifulsoup4>=4.14.3",
+  "sounddevice>=0.5.1",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parcera"
-version = "0.14.0"
+version = "0.14.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "parcera"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "chrono",
  "env_logger",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "parcera"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "chrono",
  "env_logger",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -98,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +519,12 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "colorchoice"
@@ -1718,6 +1730,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2732,6 +2750,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-http",
+ "tauri-plugin-localhost",
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-window-state",
@@ -4526,6 +4545,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-localhost"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8d72c024121b1a3d9268293d49a56baf01a8c785561c85d17872588b839e55"
+dependencies = [
+ "http",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.18",
+ "tiny_http",
+]
+
+[[package]]
 name = "tauri-plugin-opener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4786,6 +4820,18 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,6 +23,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-window-state = "2"
+tauri-plugin-localhost = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml = "0.9"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcera"
-version = "0.14.0"
+version = "0.14.1"
 description = "Parcera - AI Avatar Companion"
 authors = []
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcera"
-version = "0.13.0"
+version = "0.14.0"
 description = "Parcera - AI Avatar Companion"
 authors = []
 edition = "2021"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,7 +23,6 @@
     "shell:allow-kill",
     "shell:allow-stdin-write",
     "window-state:allow-restore-state",
-    "window-state:allow-save-window-state",
-    "localhost:default"
+    "window-state:allow-save-window-state"
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "shell:allow-kill",
     "shell:allow-stdin-write",
     "window-state:allow-restore-state",
-    "window-state:allow-save-window-state"
+    "window-state:allow-save-window-state",
+    "localhost:default"
   ]
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,6 +3,7 @@ use crate::settings_store::parse_default_yaml;
 use crate::types::OpResult;
 use crate::AppState;
 use serde_json::Value;
+use std::time::Duration;
 use tauri::{Emitter, State};
 
 #[tauri::command]
@@ -38,9 +39,16 @@ pub async fn save_settings(
 
     let _ = app_handle.emit("settings-changed", &settings);
 
-    let restart_required = notify_python_reload(port, &settings).await;
+    // Disk save is complete. Notify Python in the background so the save
+    // response is not blocked by Python startup time or a slow reload.
+    let settings_clone = settings.clone();
+    let app_clone = app_handle.clone();
+    tauri::async_runtime::spawn(async move {
+        let restart_required = notify_python_reload(port, &settings_clone).await;
+        let _ = app_clone.emit("python-reload-done", restart_required);
+    });
 
-    Ok(OpResult::ok_with_restart(restart_required))
+    Ok(OpResult::ok())
 }
 
 #[tauri::command]
@@ -66,14 +74,14 @@ pub async fn update_setting(
 
 async fn notify_python_reload(port: u16, settings: &Value) -> bool {
     let url = python_url(port, "/config/reload");
-    if let Ok(resp) = reqwest::Client::new()
-        .post(&url)
-        .json(settings)
-        .send()
-        .await
-    {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .unwrap_or_default();
+    if let Ok(resp) = client.post(&url).json(settings).send().await {
         if let Ok(body) = resp.json::<Value>().await {
-            return body.get("restart_required")
+            return body
+                .get("restart_required")
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
         }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -38,9 +38,9 @@ pub async fn save_settings(
 
     let _ = app_handle.emit("settings-changed", &settings);
 
-    notify_python_reload(port, &settings).await;
+    let restart_required = notify_python_reload(port, &settings).await;
 
-    Ok(OpResult::ok())
+    Ok(OpResult::ok_with_restart(restart_required))
 }
 
 #[tauri::command]
@@ -64,13 +64,21 @@ pub async fn update_setting(
     Ok(OpResult::ok())
 }
 
-async fn notify_python_reload(port: u16, settings: &Value) {
+async fn notify_python_reload(port: u16, settings: &Value) -> bool {
     let url = python_url(port, "/config/reload");
-    let _ = reqwest::Client::new()
+    if let Ok(resp) = reqwest::Client::new()
         .post(&url)
         .json(settings)
         .send()
-        .await;
+        .await
+    {
+        if let Ok(body) = resp.json::<Value>().await {
+            return body.get("restart_required")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -67,7 +67,10 @@ pub async fn update_setting(
 
     let _ = app_handle.emit("settings-changed", &all_settings);
 
-    notify_python_reload(port, &all_settings).await;
+    let settings_for_bg = all_settings.clone();
+    tauri::async_runtime::spawn(async move {
+        notify_python_reload(port, &settings_for_bg).await;
+    });
 
     Ok(OpResult::ok())
 }

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -51,6 +51,18 @@ pub async fn get_avatar_window_bounds(
 }
 
 #[tauri::command]
+pub async fn set_window_always_on_top(
+    app_handle: tauri::AppHandle,
+    window_type: String,
+    always_on_top: bool,
+) -> Result<(), String> {
+    if let Some(win) = app_handle.get_webview_window(&window_type) {
+        win.set_always_on_top(always_on_top).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+#[tauri::command]
 pub async fn set_window_visible(
     app_handle: tauri::AppHandle,
     window_type: String,

--- a/src-tauri/src/commands/windows.rs
+++ b/src-tauri/src/commands/windows.rs
@@ -50,6 +50,22 @@ pub async fn get_avatar_window_bounds(
     }))
 }
 
+#[tauri::command]
+pub async fn set_window_visible(
+    app_handle: tauri::AppHandle,
+    window_type: String,
+    visible: bool,
+) -> Result<(), String> {
+    if let Some(win) = app_handle.get_webview_window(&window_type) {
+        if visible {
+            win.show().map_err(|e| e.to_string())?;
+        } else {
+            win.hide().map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use crate::types::Rect;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,14 @@ pub fn run() {
     env_logger::init();
     log::info!("[Parcera] Starting (RUST_LOG={})", std::env::var("RUST_LOG").unwrap_or_else(|_| "unset".into()));
 
+    // Read the default YAML to determine frontend_port before the Tauri builder
+    // is constructed (tauri-plugin-localhost requires the port at registration time).
+    // Falls back to 8677 if parsing fails.
+    let default_frontend_port: u16 = settings_store::parse_default_yaml()
+        .ok()
+        .and_then(|v| v["app"]["frontend_port"].as_u64())
+        .unwrap_or(8677) as u16;
+
     // Hoist python_child to function scope so both the setup closure and the
     // run-event handler can share the same Arc without lifetime issues.
     let python_child: Arc<Mutex<Option<CommandChild>>> = Arc::new(Mutex::new(None));
@@ -38,6 +46,7 @@ pub fn run() {
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(tauri_plugin_localhost::Builder::new(default_frontend_port).build())
         .setup(move |app| {
             let data_dir = app.path().app_data_dir()?;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -115,6 +115,10 @@ pub fn run() {
                         if cfg["visible"].as_bool() == Some(false) {
                             let _ = win.hide();
                         }
+                        // Apply always-on-top if explicitly set to true
+                        if cfg["alwaysOnTop"].as_bool() == Some(true) {
+                            let _ = win.set_always_on_top(true);
+                        }
                     }
                 }
             }
@@ -139,6 +143,7 @@ pub fn run() {
             commands::windows::save_window_bounds,
             commands::windows::get_avatar_window_bounds,
             commands::windows::set_window_visible,
+            commands::windows::set_window_always_on_top,
             commands::dialogs::select_directory,
             commands::logs::get_log_history,
             commands::twitch::twitch_start_auth,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,10 @@ pub fn run() {
                                 tauri::LogicalSize { width: w, height: h },
                             ));
                         }
+                        // Hide window if visible == false (default: show)
+                        if cfg["visible"].as_bool() == Some(false) {
+                            let _ = win.hide();
+                        }
                     }
                 }
             }
@@ -134,6 +138,7 @@ pub fn run() {
             commands::settings::reload_settings,
             commands::windows::save_window_bounds,
             commands::windows::get_avatar_window_bounds,
+            commands::windows::set_window_visible,
             commands::dialogs::select_directory,
             commands::logs::get_log_history,
             commands::twitch::twitch_start_auth,

--- a/src-tauri/src/settings_store.rs
+++ b/src-tauri/src/settings_store.rs
@@ -56,6 +56,12 @@ impl SettingsStore {
     pub fn get_port(&self) -> u16 {
         self.data["app"]["port"].as_u64().unwrap_or(8676) as u16
     }
+
+    pub fn get_frontend_port(&self) -> u16 {
+        self.data["app"]["frontend_port"]
+            .as_u64()
+            .unwrap_or_else(|| (self.get_port() as u64) + 1) as u16
+    }
 }
 
 /// Parse the bundled default YAML into a JSON Value.
@@ -201,5 +207,23 @@ mod tests {
         let mut store = SettingsStore::new(path);
         store.set_all(json!({ "app": { "port": 9876 } }));
         assert_eq!(store.get_port(), 9876);
+    }
+
+    #[test]
+    fn store_get_frontend_port_defaults_to_port_plus_one() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut store = SettingsStore::new(path);
+        store.set_all(json!({ "app": { "port": 8676 } }));
+        assert_eq!(store.get_frontend_port(), 8677);
+    }
+
+    #[test]
+    fn store_get_frontend_port_reads_explicit_value() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("config.json");
+        let mut store = SettingsStore::new(path);
+        store.set_all(json!({ "app": { "port": 8676, "frontend_port": 9000 } }));
+        assert_eq!(store.get_frontend_port(), 9000);
     }
 }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -8,14 +8,19 @@ pub struct OpResult {
     pub success: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub restart_required: Option<bool>,
 }
 
 impl OpResult {
     pub fn ok() -> Self {
-        Self { success: true, error: None }
+        Self { success: true, error: None, restart_required: None }
     }
     pub fn err(msg: impl Into<String>) -> Self {
-        Self { success: false, error: Some(msg.into()) }
+        Self { success: false, error: Some(msg.into()), restart_required: None }
+    }
+    pub fn ok_with_restart(restart: bool) -> Self {
+        Self { success: true, error: None, restart_required: if restart { Some(true) } else { None } }
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Parcera",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "identifier": "Parcera",
   "build": {
     "frontendDist": "../dist/web",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "version": "0.13.0",
   "identifier": "Parcera",
   "build": {
-    "frontendDist": "../dist",
+    "frontendDist": "../dist/web",
     "devUrl": "http://localhost:5173",
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Parcera",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "Parcera",
   "build": {
     "frontendDist": "../dist/web",

--- a/src/core/interaction.py
+++ b/src/core/interaction.py
@@ -15,8 +15,12 @@ class InteractionController:
         self.avatar = avatar
         self.config = config
 
-    async def on_recognized(self, session_id: str, text: str, is_filtered: bool = False):
-        """Callback handled after STT processing."""
+    async def on_recognized(self, session_id: str, text: str, is_filtered: bool = False) -> bool:
+        """Callback handled after STT processing.
+
+        Returns True if the utterance was accepted and the STS pipeline should
+        be invoked, False if it was dropped (busy guard, filtered, etc.).
+        """
         # Hot-reload check (Always check, even if filtered, so settings stay fresh)
         if self.config.refresh():
             self.avatar.apply_runtime_config()
@@ -26,18 +30,18 @@ class InteractionController:
         if self.avatar.is_busy(source="twitch"):
             logger.info(f"Dropping user input because AI is busy with Twitch: {text}")
             self.avatar.set_busy(session_id, False)
-            return
-            
+            return False
+
         if self.avatar.is_busy(source="training"):
             logger.info(f"Dropping user input because AI is busy with Training: {text}")
             self.avatar.set_busy(session_id, False)
-            return
+            return False
 
         # 1. Ignored Speech
         if is_filtered:
             chat_logger.log_user(text, ignored=True)
             self.avatar.set_busy(session_id, False)
-            return
+            return False
 
         # 2. Approved Speech
         chat_logger.log_user(text)
@@ -63,6 +67,8 @@ class InteractionController:
                     })
                 except Exception as e:
                     logger.error(f"Error sending 'thinking' signal: {e}")
+
+        return True
 
     async def on_response(self, aiavatar_response, sts_response):
         """Callback handled when AI starts generating a response."""

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -14,7 +14,7 @@ the frontend from running a redundant amplitude comparison.
 
 import asyncio
 import logging
-from typing import Optional, Callable, Awaitable
+from typing import Any, Coroutine, Optional, Callable
 
 import numpy as np
 
@@ -42,7 +42,7 @@ class MicAnalyzer:
 
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
-        self._stream = None
+        self._stream: Optional[Any] = None
         self._mic_device: Optional[str] = None
         # Default threshold tuned for typical system microphone without browser AGC.
         # Users adjust vad.volume_db_threshold in settings to match their meter reading.
@@ -55,15 +55,15 @@ class MicAnalyzer:
         self._speech_chunk_count: int = 0
 
         # Callbacks (set before calling start())
-        self._stt_callback: Optional[Callable[[bytes], Awaitable[None]]] = None
-        self._broadcast_callback: Optional[Callable[[dict], Awaitable[None]]] = None
+        self._stt_callback: Optional[Callable[[bytes], Coroutine[Any, Any, None]]] = None
+        self._broadcast_callback: Optional[Callable[[dict], Coroutine[Any, Any, None]]] = None
 
     # ── Configuration ─────────────────────────────────────────────────────────
 
-    def set_stt_callback(self, callback: Callable[[bytes], Awaitable[None]]) -> None:
+    def set_stt_callback(self, callback: Callable[[bytes], Coroutine[Any, Any, None]]) -> None:
         self._stt_callback = callback
 
-    def set_broadcast_callback(self, callback: Callable[[dict], Awaitable[None]]) -> None:
+    def set_broadcast_callback(self, callback: Callable[[dict], Coroutine[Any, Any, None]]) -> None:
         self._broadcast_callback = callback
 
     def set_threshold_db(self, db: float) -> None:
@@ -76,7 +76,7 @@ class MicAnalyzer:
 
     def start(self) -> None:
         try:
-            import sounddevice as sd  # lazy import — optional dependency
+            import sounddevice as sd  # type: ignore[import-untyped]  # lazy import — optional dependency
             self._stream = sd.InputStream(
                 samplerate=SAMPLE_RATE,
                 channels=1,

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -23,11 +23,49 @@ MIN_SPEECH_CHUNKS = 5         # ~160ms minimum speech to reject brief noise spik
 # Matches the thresholds used in ui/renderer/lib/audio.ts VOWEL_BOUNDARIES_HZ.
 _VOWEL_BOUNDARIES_HZ = {'u': 600, 'o': 1500, 'a': 3000, 'e': 5000}
 
-# Amplitude scale applied before sending to the frontend peak meter.
-# Python sounddevice captures raw audio without browser AGC, so levels are
-# typically 3-6x lower than what getUserMedia returns.  Scaling by 10 brings
-# the peak meter into a comparable range without hard-clipping.
-_AMPLITUDE_SCALE = 10.0
+
+class _SoftwareAGC:
+    """
+    Peak-hold AGC that normalises raw mic RMS to a consistent target level.
+
+    Mimics the browser's WebRTC Automatic Gain Control: speech is boosted to
+    TARGET_RMS regardless of the physical microphone gain, while a noise gate
+    (NOISE_FLOOR) prevents amplifying silence into false positives.
+
+    Algorithm:
+      - If current RMS > tracked peak  → update peak, reset hold counter
+      - While hold counter > 0         → keep peak stable (prevents pumping)
+      - After hold expires             → peak decays slowly (handles level drops)
+      - Gain = TARGET_RMS / peak, capped at MAX_GAIN
+    """
+
+    TARGET_RMS = 0.12       # Normalise speech to ~-18 dBFS (matches browser AGC)
+    MAX_GAIN = 40.0         # Cap at +32 dB to avoid amplifying deep silence
+    NOISE_FLOOR = 0.0005    # Below this RMS, apply no gain (pure silence / noise gate)
+    HOLD_CHUNKS = 30        # Hold peak for ~1 s before allowing decay
+    DECAY_PER_CHUNK = 0.995 # ~0.5 dB/s decay — slow enough to avoid pumping artefacts
+
+    def __init__(self) -> None:
+        self._peak: float = 0.001
+        self._hold: int = 0
+
+    def process(self, rms: float) -> float:
+        """Return the AGC-normalised RMS for *rms*; also updates internal state."""
+        # Update peak tracker
+        if rms > self._peak:
+            self._peak = rms
+            self._hold = self.HOLD_CHUNKS
+        elif self._hold > 0:
+            self._hold -= 1
+        else:
+            self._peak = max(self._peak * self.DECAY_PER_CHUNK, 0.001)
+
+        # Noise gate: don't boost near-silence
+        if rms < self.NOISE_FLOOR:
+            return rms
+
+        gain = min(self.TARGET_RMS / self._peak, self.MAX_GAIN)
+        return float(np.clip(rms * gain, 0.0, 1.0))
 
 
 class MicAnalyzer:
@@ -43,10 +81,10 @@ class MicAnalyzer:
         self._loop = loop
         self._stream = None
         self._mic_device: Optional[str] = None
-        # Lower default threshold than browser-based VAD because Python
-        # sounddevice has no Automatic Gain Control; typical speech sits at
-        # -35 to -45 dBFS here vs -15 to -25 dBFS in the browser.
-        self._threshold_db: float = -40.0
+        # With software AGC normalising to ~-18 dBFS, a -25 dB threshold gives
+        # comfortable headroom for detecting speech while ignoring residual noise.
+        self._threshold_db: float = -25.0
+        self._agc = _SoftwareAGC()
 
         # VAD state
         self._vad_buffer: list[bytes] = []
@@ -86,7 +124,10 @@ class MicAnalyzer:
                 callback=self._audio_callback,
             )
             self._stream.start()
-            logger.info(f"MicAnalyzer started (device={self._mic_device or 'default'}, threshold={self._threshold_db}dB)")
+            logger.info(
+                f"MicAnalyzer started (device={self._mic_device or 'default'}, "
+                f"threshold={self._threshold_db}dB, AGC target={_SoftwareAGC.TARGET_RMS})"
+            )
         except Exception as e:
             logger.error(f"MicAnalyzer failed to start: {e}")
 
@@ -106,21 +147,24 @@ class MicAnalyzer:
         audio_int16 = indata[:, 0].copy()  # mono, shape (frames,), dtype int16
         audio_float = audio_int16.astype(np.float32) / 32768.0
 
-        rms = float(np.sqrt(np.mean(audio_float ** 2)))
+        raw_rms = float(np.sqrt(np.mean(audio_float ** 2)))
+        boosted_rms = self._agc.process(raw_rms)
 
-        # --- Lipsync broadcast ---
-        amplitude = float(np.clip(rms * _AMPLITUDE_SCALE, 0.0, 1.0))
-        vowel = self._estimate_vowel(audio_float, rms)
-
+        # --- Lipsync broadcast (AGC-normalised amplitude) ---
+        vowel = self._estimate_vowel(audio_float, raw_rms)
         if self._broadcast_callback:
             asyncio.run_coroutine_threadsafe(
-                self._broadcast_callback({"type": "user_lipsync", "vowel": vowel, "amplitude": amplitude}),
+                self._broadcast_callback({
+                    "type": "user_lipsync",
+                    "vowel": vowel,
+                    "amplitude": boosted_rms,
+                }),
                 self._loop,
             )
 
-        # --- Energy VAD for STT ---
+        # --- Energy VAD for STT (using AGC-normalised dB) ---
         if self._stt_callback:
-            db = 20.0 * np.log10(max(rms, 1e-10))
+            db = 20.0 * np.log10(max(boosted_rms, 1e-10))
             if db > self._threshold_db:
                 self._is_speaking = True
                 self._silence_count = 0
@@ -134,7 +178,7 @@ class MicAnalyzer:
                         audio_data = b''.join(self._vad_buffer)
                         logger.debug(
                             f"VAD flush: {self._speech_chunk_count} speech chunks "
-                            f"({len(audio_data)//2/SAMPLE_RATE:.2f}s), last db={db:.1f}"
+                            f"({len(audio_data) // 2 / SAMPLE_RATE:.2f}s)"
                         )
                         asyncio.run_coroutine_threadsafe(
                             self._stt_callback(audio_data),
@@ -142,8 +186,8 @@ class MicAnalyzer:
                         )
                     else:
                         logger.debug(
-                            f"VAD flush skipped: only {self._speech_chunk_count} speech chunks "
-                            f"(min={MIN_SPEECH_CHUNKS})"
+                            f"VAD: skipped flush — only {self._speech_chunk_count} "
+                            f"speech chunks (min={MIN_SPEECH_CHUNKS})"
                         )
                     self._vad_buffer = []
                     self._is_speaking = False

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -1,0 +1,152 @@
+"""
+MicAnalyzer: sounddevice-based microphone capture for OBS Browser Source support.
+
+Captures audio from the system microphone, then:
+1. Broadcasts user_lipsync events (vowel + amplitude) to all WS clients
+2. Feeds audio to the STT pipeline via a simple energy-based VAD
+"""
+
+import asyncio
+import logging
+from typing import Optional, Callable, Awaitable
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 16000
+CHUNK_FRAMES = 512  # ~32ms per callback at 16kHz
+SILENCE_CHUNKS_TO_FLUSH = 15  # ~480ms of post-speech silence before STT trigger
+
+# Spectral centroid boundaries (Hz) for Japanese vowel classification.
+# Matches the thresholds used in ui/renderer/lib/audio.ts VOWEL_BOUNDARIES_HZ.
+_VOWEL_BOUNDARIES_HZ = {'u': 600, 'o': 1500, 'a': 3000, 'e': 5000}
+
+
+class MicAnalyzer:
+    """
+    Captures microphone audio via sounddevice and performs two duties:
+    - Broadcasts ``user_lipsync`` JSON events to all connected WebSocket clients
+      (used by OBS Browser Source user avatar).
+    - Runs a lightweight energy-based VAD and feeds detected utterances to the
+      STT pipeline so that STT no longer depends on browser PCM streaming.
+    """
+
+    def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self._stream = None
+        self._mic_device: Optional[str] = None
+        self._threshold_db: float = -25.0
+
+        # VAD state
+        self._vad_buffer: list[bytes] = []
+        self._is_speaking: bool = False
+        self._silence_count: int = 0
+
+        # Callbacks (set before calling start())
+        self._stt_callback: Optional[Callable[[bytes], Awaitable[None]]] = None
+        self._broadcast_callback: Optional[Callable[[dict], Awaitable[None]]] = None
+
+    # ── Configuration ─────────────────────────────────────────────────────────
+
+    def set_stt_callback(self, callback: Callable[[bytes], Awaitable[None]]) -> None:
+        self._stt_callback = callback
+
+    def set_broadcast_callback(self, callback: Callable[[dict], Awaitable[None]]) -> None:
+        self._broadcast_callback = callback
+
+    def set_threshold_db(self, db: float) -> None:
+        self._threshold_db = db
+
+    def set_mic_device(self, device: Optional[str]) -> None:
+        self._mic_device = None if (not device or device == 'default') else device
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def start(self) -> None:
+        try:
+            import sounddevice as sd  # lazy import — optional dependency
+            self._stream = sd.InputStream(
+                samplerate=SAMPLE_RATE,
+                channels=1,
+                dtype='int16',
+                blocksize=CHUNK_FRAMES,
+                device=self._mic_device,
+                callback=self._audio_callback,
+            )
+            self._stream.start()
+            logger.info(f"MicAnalyzer started (device={self._mic_device or 'default'})")
+        except Exception as e:
+            logger.error(f"MicAnalyzer failed to start: {e}")
+
+    def stop(self) -> None:
+        if self._stream:
+            try:
+                self._stream.stop()
+                self._stream.close()
+            except Exception as e:
+                logger.warning(f"MicAnalyzer stop error: {e}")
+            self._stream = None
+            logger.info("MicAnalyzer stopped")
+
+    # ── Audio Processing (sounddevice callback — runs in a C thread) ──────────
+
+    def _audio_callback(self, indata, frames, time, status) -> None:
+        audio_int16 = indata[:, 0].copy()  # mono, shape (frames,), dtype int16
+        audio_float = audio_int16.astype(np.float32) / 32768.0
+
+        rms = float(np.sqrt(np.mean(audio_float ** 2)))
+
+        # --- Lipsync broadcast ---
+        amplitude = float(np.clip(rms * 5.0, 0.0, 1.0))
+        vowel = self._estimate_vowel(audio_float, rms)
+
+        if self._broadcast_callback:
+            asyncio.run_coroutine_threadsafe(
+                self._broadcast_callback({"type": "user_lipsync", "vowel": vowel, "amplitude": amplitude}),
+                self._loop,
+            )
+
+        # --- Energy VAD for STT ---
+        if self._stt_callback:
+            db = 20.0 * np.log10(max(rms, 1e-10))
+            if db > self._threshold_db:
+                self._is_speaking = True
+                self._silence_count = 0
+                self._vad_buffer.append(audio_int16.tobytes())
+            elif self._is_speaking:
+                self._vad_buffer.append(audio_int16.tobytes())
+                self._silence_count += 1
+                if self._silence_count >= SILENCE_CHUNKS_TO_FLUSH:
+                    audio_data = b''.join(self._vad_buffer)
+                    self._vad_buffer = []
+                    self._is_speaking = False
+                    self._silence_count = 0
+                    asyncio.run_coroutine_threadsafe(
+                        self._stt_callback(audio_data),
+                        self._loop,
+                    )
+
+    # ── Vowel Estimation ──────────────────────────────────────────────────────
+
+    def _estimate_vowel(self, audio: np.ndarray, rms: float) -> str:
+        if rms < 0.005:
+            return 'n'
+
+        fft = np.abs(np.fft.rfft(audio))
+        freqs = np.fft.rfftfreq(len(audio), d=1.0 / SAMPLE_RATE)
+        total = float(np.sum(fft))
+        if total < 1e-10:
+            return 'n'
+
+        centroid = float(np.dot(freqs, fft)) / total
+
+        if centroid < _VOWEL_BOUNDARIES_HZ['u']:
+            return 'u'
+        if centroid < _VOWEL_BOUNDARIES_HZ['o']:
+            return 'o'
+        if centroid < _VOWEL_BOUNDARIES_HZ['a']:
+            return 'a'
+        if centroid < _VOWEL_BOUNDARIES_HZ['e']:
+            return 'e'
+        return 'i'

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -2,8 +2,14 @@
 MicAnalyzer: sounddevice-based microphone capture for OBS Browser Source support.
 
 Captures audio from the system microphone, then:
-1. Broadcasts user_lipsync events (vowel + amplitude) to all WS clients
+1. Broadcasts user_lipsync events (vowel + amplitude + speaking) to all WS clients
 2. Feeds audio to the STT pipeline via a simple energy-based VAD
+
+The ``amplitude`` field carries the raw linear RMS so the frontend peak meter
+reflects the actual physical level — allowing users to calibrate
+``vad.volume_db_threshold`` against what they see on the meter.
+The ``speaking`` field is the VAD decision at the Python threshold, freeing
+the frontend from running a redundant amplitude comparison.
 """
 
 import asyncio
@@ -24,67 +30,22 @@ MIN_SPEECH_CHUNKS = 5         # ~160ms minimum speech to reject brief noise spik
 _VOWEL_BOUNDARIES_HZ = {'u': 600, 'o': 1500, 'a': 3000, 'e': 5000}
 
 
-class _SoftwareAGC:
-    """
-    Peak-hold AGC that normalises raw mic RMS to a consistent target level.
-
-    Mimics the browser's WebRTC Automatic Gain Control: speech is boosted to
-    TARGET_RMS regardless of the physical microphone gain, while a noise gate
-    (NOISE_FLOOR) prevents amplifying silence into false positives.
-
-    Algorithm:
-      - If current RMS > tracked peak  → update peak, reset hold counter
-      - While hold counter > 0         → keep peak stable (prevents pumping)
-      - After hold expires             → peak decays slowly (handles level drops)
-      - Gain = TARGET_RMS / peak, capped at MAX_GAIN
-    """
-
-    TARGET_RMS = 0.12       # Normalise speech to ~-18 dBFS (matches browser AGC)
-    MAX_GAIN = 40.0         # Cap at +32 dB to avoid amplifying deep silence
-    NOISE_FLOOR = 0.0005    # Below this RMS, apply no gain (pure silence / noise gate)
-    HOLD_CHUNKS = 30        # Hold peak for ~1 s before allowing decay
-    DECAY_PER_CHUNK = 0.995 # ~0.5 dB/s decay — slow enough to avoid pumping artefacts
-
-    def __init__(self) -> None:
-        self._peak: float = 0.001
-        self._hold: int = 0
-
-    def process(self, rms: float) -> float:
-        """Return the AGC-normalised RMS for *rms*; also updates internal state."""
-        # Update peak tracker
-        if rms > self._peak:
-            self._peak = rms
-            self._hold = self.HOLD_CHUNKS
-        elif self._hold > 0:
-            self._hold -= 1
-        else:
-            self._peak = max(self._peak * self.DECAY_PER_CHUNK, 0.001)
-
-        # Noise gate: don't boost near-silence
-        if rms < self.NOISE_FLOOR:
-            return rms
-
-        gain = min(self.TARGET_RMS / self._peak, self.MAX_GAIN)
-        return float(np.clip(rms * gain, 0.0, 1.0))
-
-
 class MicAnalyzer:
     """
     Captures microphone audio via sounddevice and performs two duties:
     - Broadcasts ``user_lipsync`` JSON events to all connected WebSocket clients
-      (used by OBS Browser Source user avatar).
+      (used by both OBS Browser Source and the Tauri User Window).
     - Runs a lightweight energy-based VAD and feeds detected utterances to the
-      STT pipeline so that STT no longer depends on browser PCM streaming.
+      STT pipeline.
     """
 
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
         self._stream = None
         self._mic_device: Optional[str] = None
-        # With software AGC normalising to ~-18 dBFS, a -25 dB threshold gives
-        # comfortable headroom for detecting speech while ignoring residual noise.
-        self._threshold_db: float = -25.0
-        self._agc = _SoftwareAGC()
+        # Default threshold tuned for typical system microphone without browser AGC.
+        # Users adjust vad.volume_db_threshold in settings to match their meter reading.
+        self._threshold_db: float = -35.0
 
         # VAD state
         self._vad_buffer: list[bytes] = []
@@ -126,7 +87,7 @@ class MicAnalyzer:
             self._stream.start()
             logger.info(
                 f"MicAnalyzer started (device={self._mic_device or 'default'}, "
-                f"threshold={self._threshold_db}dB, AGC target={_SoftwareAGC.TARGET_RMS})"
+                f"threshold={self._threshold_db}dB)"
             )
         except Exception as e:
             logger.error(f"MicAnalyzer failed to start: {e}")
@@ -147,25 +108,28 @@ class MicAnalyzer:
         audio_int16 = indata[:, 0].copy()  # mono, shape (frames,), dtype int16
         audio_float = audio_int16.astype(np.float32) / 32768.0
 
-        raw_rms = float(np.sqrt(np.mean(audio_float ** 2)))
-        boosted_rms = self._agc.process(raw_rms)
+        rms = float(np.sqrt(np.mean(audio_float ** 2)))
+        db = 20.0 * np.log10(max(rms, 1e-10))
+        speaking = bool(db > self._threshold_db)
 
-        # --- Lipsync broadcast (AGC-normalised amplitude) ---
-        vowel = self._estimate_vowel(audio_float, raw_rms)
+        # --- Lipsync broadcast ---
+        # amplitude = raw linear RMS so the frontend peak meter shows the
+        # physical signal level, making vad.volume_db_threshold calibratable.
+        vowel = self._estimate_vowel(audio_float, rms)
         if self._broadcast_callback:
             asyncio.run_coroutine_threadsafe(
                 self._broadcast_callback({
                     "type": "user_lipsync",
                     "vowel": vowel,
-                    "amplitude": boosted_rms,
+                    "amplitude": rms,
+                    "speaking": speaking,
                 }),
                 self._loop,
             )
 
-        # --- Energy VAD for STT (using AGC-normalised dB) ---
+        # --- Energy VAD for STT ---
         if self._stt_callback:
-            db = 20.0 * np.log10(max(boosted_rms, 1e-10))
-            if db > self._threshold_db:
+            if speaking:
                 self._is_speaking = True
                 self._silence_count = 0
                 self._speech_chunk_count += 1

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -17,10 +17,17 @@ logger = logging.getLogger(__name__)
 SAMPLE_RATE = 16000
 CHUNK_FRAMES = 512  # ~32ms per callback at 16kHz
 SILENCE_CHUNKS_TO_FLUSH = 15  # ~480ms of post-speech silence before STT trigger
+MIN_SPEECH_CHUNKS = 5         # ~160ms minimum speech to reject brief noise spikes
 
 # Spectral centroid boundaries (Hz) for Japanese vowel classification.
 # Matches the thresholds used in ui/renderer/lib/audio.ts VOWEL_BOUNDARIES_HZ.
 _VOWEL_BOUNDARIES_HZ = {'u': 600, 'o': 1500, 'a': 3000, 'e': 5000}
+
+# Amplitude scale applied before sending to the frontend peak meter.
+# Python sounddevice captures raw audio without browser AGC, so levels are
+# typically 3-6x lower than what getUserMedia returns.  Scaling by 10 brings
+# the peak meter into a comparable range without hard-clipping.
+_AMPLITUDE_SCALE = 10.0
 
 
 class MicAnalyzer:
@@ -36,12 +43,16 @@ class MicAnalyzer:
         self._loop = loop
         self._stream = None
         self._mic_device: Optional[str] = None
-        self._threshold_db: float = -25.0
+        # Lower default threshold than browser-based VAD because Python
+        # sounddevice has no Automatic Gain Control; typical speech sits at
+        # -35 to -45 dBFS here vs -15 to -25 dBFS in the browser.
+        self._threshold_db: float = -40.0
 
         # VAD state
         self._vad_buffer: list[bytes] = []
         self._is_speaking: bool = False
         self._silence_count: int = 0
+        self._speech_chunk_count: int = 0
 
         # Callbacks (set before calling start())
         self._stt_callback: Optional[Callable[[bytes], Awaitable[None]]] = None
@@ -75,7 +86,7 @@ class MicAnalyzer:
                 callback=self._audio_callback,
             )
             self._stream.start()
-            logger.info(f"MicAnalyzer started (device={self._mic_device or 'default'})")
+            logger.info(f"MicAnalyzer started (device={self._mic_device or 'default'}, threshold={self._threshold_db}dB)")
         except Exception as e:
             logger.error(f"MicAnalyzer failed to start: {e}")
 
@@ -98,7 +109,7 @@ class MicAnalyzer:
         rms = float(np.sqrt(np.mean(audio_float ** 2)))
 
         # --- Lipsync broadcast ---
-        amplitude = float(np.clip(rms * 5.0, 0.0, 1.0))
+        amplitude = float(np.clip(rms * _AMPLITUDE_SCALE, 0.0, 1.0))
         vowel = self._estimate_vowel(audio_float, rms)
 
         if self._broadcast_callback:
@@ -113,19 +124,31 @@ class MicAnalyzer:
             if db > self._threshold_db:
                 self._is_speaking = True
                 self._silence_count = 0
+                self._speech_chunk_count += 1
                 self._vad_buffer.append(audio_int16.tobytes())
             elif self._is_speaking:
                 self._vad_buffer.append(audio_int16.tobytes())
                 self._silence_count += 1
                 if self._silence_count >= SILENCE_CHUNKS_TO_FLUSH:
-                    audio_data = b''.join(self._vad_buffer)
+                    if self._speech_chunk_count >= MIN_SPEECH_CHUNKS:
+                        audio_data = b''.join(self._vad_buffer)
+                        logger.debug(
+                            f"VAD flush: {self._speech_chunk_count} speech chunks "
+                            f"({len(audio_data)//2/SAMPLE_RATE:.2f}s), last db={db:.1f}"
+                        )
+                        asyncio.run_coroutine_threadsafe(
+                            self._stt_callback(audio_data),
+                            self._loop,
+                        )
+                    else:
+                        logger.debug(
+                            f"VAD flush skipped: only {self._speech_chunk_count} speech chunks "
+                            f"(min={MIN_SPEECH_CHUNKS})"
+                        )
                     self._vad_buffer = []
                     self._is_speaking = False
                     self._silence_count = 0
-                    asyncio.run_coroutine_threadsafe(
-                        self._stt_callback(audio_data),
-                        self._loop,
-                    )
+                    self._speech_chunk_count = 0
 
     # ── Vowel Estimation ──────────────────────────────────────────────────────
 

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -140,6 +140,8 @@ class MicAnalyzer:
                     logger.debug(f"VAD: forced early flush after {self._speech_chunk_count} chunks")
                     asyncio.run_coroutine_threadsafe(self._stt_callback(audio_data), self._loop)
                     self._vad_buffer = []
+                    self._is_speaking = False
+                    self._silence_count = 0
                     self._speech_chunk_count = 0
             elif self._is_speaking:
                 self._vad_buffer.append(audio_int16.tobytes())

--- a/src/core/mic_analyzer.py
+++ b/src/core/mic_analyzer.py
@@ -24,6 +24,7 @@ SAMPLE_RATE = 16000
 CHUNK_FRAMES = 512  # ~32ms per callback at 16kHz
 SILENCE_CHUNKS_TO_FLUSH = 15  # ~480ms of post-speech silence before STT trigger
 MIN_SPEECH_CHUNKS = 5         # ~160ms minimum speech to reject brief noise spikes
+MAX_SPEECH_CHUNKS = 300       # ~9.6s max before forcing an early STT flush
 
 # Spectral centroid boundaries (Hz) for Japanese vowel classification.
 # Matches the thresholds used in ui/renderer/lib/audio.ts VOWEL_BOUNDARIES_HZ.
@@ -134,6 +135,12 @@ class MicAnalyzer:
                 self._silence_count = 0
                 self._speech_chunk_count += 1
                 self._vad_buffer.append(audio_int16.tobytes())
+                if self._speech_chunk_count >= MAX_SPEECH_CHUNKS:
+                    audio_data = b''.join(self._vad_buffer)
+                    logger.debug(f"VAD: forced early flush after {self._speech_chunk_count} chunks")
+                    asyncio.run_coroutine_threadsafe(self._stt_callback(audio_data), self._loop)
+                    self._vad_buffer = []
+                    self._speech_chunk_count = 0
             elif self._is_speaking:
                 self._vad_buffer.append(audio_int16.tobytes())
                 self._silence_count += 1

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -4,15 +4,39 @@ Parcera: Configuration API Router
 Handles /config/reload endpoint for hot-reloading settings.
 """
 import logging
+from pathlib import Path
 from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/config", tags=["Config"])
 
 
+def _find_obs_html() -> Path:
+    """Locate obs.html: bundled next to this file (production) or in ui/public (dev)."""
+    bundled = Path(__file__).parent.parent / "static" / "obs.html"
+    if bundled.exists():
+        return bundled
+    dev_path = Path(__file__).parent.parent.parent / "ui" / "public" / "obs.html"
+    if dev_path.exists():
+        return dev_path
+    return bundled  # let the caller handle the missing-file error
+
+
 def create_config_router(get_server):
     """Create the config router with a server accessor to avoid circular imports."""
+
+    @router.get("/obs.html", response_class=HTMLResponse)
+    async def obs_page():
+        """
+        Serve the standalone OBS browser-source page.
+
+        Loaded once by OBS; all subsequent data arrives via WebSocket so the
+        page survives Parcera restarts without needing a manual refresh.
+        """
+        path = _find_obs_html()
+        return HTMLResponse(content=path.read_text(encoding="utf-8"))
 
     @router.get("/settings")
     async def get_settings():

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -121,6 +121,22 @@ def create_config_router(get_server):
 
         return FileResponse(file_path)
 
+    @router.get("/mic-devices")
+    async def list_mic_devices():
+        """List available audio input devices via sounddevice for the settings UI."""
+        try:
+            import sounddevice as sd
+            devices = sd.query_devices()
+            inputs = [
+                {"value": d["name"], "label": d["name"]}
+                for d in devices
+                if d.get("max_input_channels", 0) > 0
+            ]
+            return inputs
+        except Exception as e:
+            logger.warning(f"Could not enumerate mic devices: {e}")
+            return []
+
     @router.get("/settings")
     async def get_settings():
         """Return display settings for OBS Browser Source. Credentials are stripped."""

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -52,6 +52,19 @@ def create_config_router(get_server):
         path = _find_obs_html()
         return HTMLResponse(content=path.read_text(encoding="utf-8"))
 
+    @router.get("/obs-html-path")
+    async def obs_html_path():
+        """
+        Return the file:// URI for obs.html.
+
+        The Tauri settings UI uses this to display a browser-source URL that
+        always resolves from the local filesystem — so OBS can load the page
+        even before Parcera's HTTP server is running.  The JS retry loops then
+        handle connecting to the WebSocket once Parcera starts.
+        """
+        path = _find_obs_html()
+        return {"file_uri": path.as_uri()}
+
     @router.get("/obs-asset/{avatar_type}/{filename}")
     async def serve_obs_asset(avatar_type: str, filename: str):
         """

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -5,8 +5,8 @@ Handles /config/reload endpoint for hot-reloading settings.
 """
 import logging
 from pathlib import Path
-from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import FileResponse, HTMLResponse
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,20 @@ def _find_obs_html() -> Path:
     return bundled  # let the caller handle the missing-file error
 
 
+def _find_bundled_assets(avatar_type: str) -> Path | None:
+    """Find bundled avatar assets directory for dev or production builds."""
+    candidates = [
+        # Development: project root / ui / public / assets / {type}
+        Path(__file__).parent.parent.parent / "ui" / "public" / "assets" / avatar_type,
+        # Production (macOS bundle): Contents/Resources/dist/assets/{type}
+        Path(__file__).parent.parent.parent.parent / "Resources" / "dist" / "assets" / avatar_type,
+    ]
+    for p in candidates:
+        if p.is_dir():
+            return p
+    return None
+
+
 def create_config_router(get_server):
     """Create the config router with a server accessor to avoid circular imports."""
 
@@ -37,6 +51,38 @@ def create_config_router(get_server):
         """
         path = _find_obs_html()
         return HTMLResponse(content=path.read_text(encoding="utf-8"))
+
+    @router.get("/obs-asset/{avatar_type}/{filename}")
+    async def serve_obs_asset(avatar_type: str, filename: str):
+        """
+        Serve avatar sprite images for the OBS browser source.
+
+        Proxies local filesystem images through HTTP so obs.html (served via
+        http://) can load them without hitting the file:// mixed-content block.
+        Only serves files within the configured assets_dir or bundled assets.
+        """
+        server = get_server()
+        avatar_cfg = server.config.get("avatars", {}).get(avatar_type)
+        if isinstance(avatar_cfg, dict) and avatar_cfg.get("assets_dir"):
+            assets_dir = Path(avatar_cfg["assets_dir"])
+        else:
+            assets_dir = _find_bundled_assets(avatar_type)
+
+        if assets_dir is None:
+            raise HTTPException(status_code=404, detail="Assets directory not found")
+
+        # Prevent path traversal
+        try:
+            file_path = (assets_dir / filename).resolve()
+            assets_dir.resolve().relative_to  # ensure it's a directory
+            file_path.relative_to(assets_dir.resolve())
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Access denied")
+
+        if not file_path.exists():
+            raise HTTPException(status_code=404, detail="Asset not found")
+
+        return FileResponse(file_path)
 
     @router.get("/settings")
     async def get_settings():

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -3,6 +3,7 @@ Parcera: Configuration API Router
 
 Handles /config/reload endpoint for hot-reloading settings.
 """
+import json
 import logging
 from pathlib import Path
 from fastapi import APIRouter, HTTPException, Request
@@ -132,9 +133,10 @@ def create_config_router(get_server):
 
             stt_changed = new_stt_provider != server.current_stt_provider
             tts_changed = new_tts_provider != server.current_tts_provider
-            llm_changed = new_llm_provider != server.current_llm_provider
-            
-            # If ONLY LLM changed, we can try hot-reload
+            # Detect any LLM config change (provider, model, temperature, api_key, …)
+            llm_changed = json.dumps(llm_cfg, sort_keys=True) != server.current_llm_hash
+
+            # If ONLY LLM changed, hot-reload (handles provider switch, model, temperature)
             if llm_changed and not (stt_changed or tts_changed):
                 await server.reload_llm()
                 restart_required = False

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -74,6 +74,10 @@ def create_config_router(get_server):
         http://) can load them without hitting the file:// mixed-content block.
         Only serves files within the configured assets_dir or bundled assets.
         """
+        _VALID_AVATAR_TYPES = frozenset({"user", "ai"})
+        if avatar_type not in _VALID_AVATAR_TYPES:
+            raise HTTPException(status_code=404, detail="Unknown avatar type")
+
         server = get_server()
         avatar_cfg = server.config.get("avatars", {}).get(avatar_type)
         assets_dir = None
@@ -93,7 +97,6 @@ def create_config_router(get_server):
         # Prevent path traversal
         try:
             file_path = (assets_dir / filename).resolve()
-            assets_dir.resolve().relative_to  # ensure it's a directory
             file_path.relative_to(assets_dir.resolve())
         except ValueError:
             raise HTTPException(status_code=403, detail="Access denied")

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -14,6 +14,12 @@ router = APIRouter(prefix="/config", tags=["Config"])
 def create_config_router(get_server):
     """Create the config router with a server accessor to avoid circular imports."""
 
+    @router.get("/settings")
+    async def get_settings():
+        """Return all settings as JSON. Used by OBS Browser Source (no Tauri IPC available)."""
+        server = get_server()
+        return server.config.settings
+
     @router.post("/reload")
     async def reload_config(request: Request):
         server = get_server()

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -11,7 +11,20 @@ from fastapi.responses import FileResponse, HTMLResponse
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/config", tags=["Config"])
+_SENSITIVE_PROVIDER_KEYS = frozenset({"api_key", "client_secret"})
+
+
+def _strip_credentials(settings: dict) -> dict:
+    """Return a deep copy of settings with all credential fields removed."""
+    import copy
+    safe = copy.deepcopy(settings)
+    for section in ("llm", "stt", "tts"):
+        for provider_cfg in safe.get(section, {}).get("providers", {}).values():
+            if isinstance(provider_cfg, dict):
+                for k in _SENSITIVE_PROVIDER_KEYS:
+                    provider_cfg.pop(k, None)
+    safe.pop("twitch", None)
+    return safe
 
 
 def _find_obs_html() -> Path:
@@ -40,7 +53,8 @@ def _find_bundled_assets(avatar_type: str) -> Path | None:
 
 
 def create_config_router(get_server):
-    """Create the config router with a server accessor to avoid circular imports."""
+    """Create a fresh config router with a server accessor to avoid circular imports."""
+    router = APIRouter(prefix="/config", tags=["Config"])
 
     @router.get("/obs.html", response_class=HTMLResponse)
     async def obs_page():
@@ -109,9 +123,9 @@ def create_config_router(get_server):
 
     @router.get("/settings")
     async def get_settings():
-        """Return all settings as JSON. Used by OBS Browser Source (no Tauri IPC available)."""
+        """Return display settings for OBS Browser Source. Credentials are stripped."""
         server = get_server()
-        return server.config.settings
+        return _strip_credentials(server.config.settings)
 
     @router.post("/reload")
     async def reload_config(request: Request):

--- a/src/routers/config_router.py
+++ b/src/routers/config_router.py
@@ -63,9 +63,15 @@ def create_config_router(get_server):
         """
         server = get_server()
         avatar_cfg = server.config.get("avatars", {}).get(avatar_type)
+        assets_dir = None
         if isinstance(avatar_cfg, dict) and avatar_cfg.get("assets_dir"):
-            assets_dir = Path(avatar_cfg["assets_dir"])
-        else:
+            candidate = Path(avatar_cfg["assets_dir"])
+            # Only use the configured path if it's a real filesystem directory.
+            # The default config stores Tauri-relative paths like "/assets/user"
+            # which are not valid on the filesystem.
+            if candidate.is_dir():
+                assets_dir = candidate
+        if assets_dir is None:
             assets_dir = _find_bundled_assets(avatar_type)
 
         if assets_dir is None:

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -271,10 +271,41 @@ async def lifespan(app: FastAPI):
     async def _handle_stt_audio(audio_data: bytes) -> None:
         try:
             result = await parcera_server.stt.recognize("parcera-mic-session", audio_data)
-            if result.text:
-                await parcera_server.controller.on_recognized("parcera-mic-session", result.text)
+            if not result.text:
+                return
+
+            text = result.text
+            logger.info(f"MicAnalyzer STT recognized: '{text}'")
+
+            # Use the standard AI session so thinking/response signals reach the UI
+            session_id = "parcera-session"
+            await parcera_server.controller.on_recognized(session_id, text)
+
+            # Invoke STS pipeline (LLM → TTS) and broadcast each chunk to all UI clients
+            import base64 as _b64
+            from aiavatar.sts.models import STSRequest
+            from dataclasses import dataclass
+
+            @dataclass
+            class _MockResp:
+                session_id: str
+
+            async for r in parcera_server.aiavatar_server.sts.invoke(
+                STSRequest(text=text, session_id=session_id)
+            ):
+                msg: dict = {"type": r.type, "text": r.text}
+                if r.audio_data:
+                    msg["audio_data"] = _b64.b64encode(r.audio_data).decode()
+                for sid, ws in parcera_server.aiavatar_server.websockets.items():
+                    if sid != TWITCH_SESSION_ID:
+                        try:
+                            await ws.send_json(msg)
+                        except Exception:
+                            pass
+                if r.type == "final":
+                    await parcera_server.controller.on_response(_MockResp(session_id), r)
         except Exception as e:
-            logger.error(f"MicAnalyzer STT error: {e}")
+            logger.error(f"MicAnalyzer STT error: {e}", exc_info=True)
 
     mic = MicAnalyzer(loop)
     mic.set_broadcast_callback(_broadcast_user_lipsync)

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -138,7 +138,7 @@ class ParceraServer(ParceraAvatarBase):
             session_state_manager=session_state_manager,
             performance_recorder=performance_recorder,
             voice_recorder_dir=voices_dir,
-            merge_request_threshold=self.config.get("merge_request_threshold", 3.0),
+            merge_request_threshold=self.config.get("merge_request_threshold", 0.6),
             debug=self.config.verbose,
             voice_recorder_enabled=False
         )
@@ -188,6 +188,15 @@ class ParceraServer(ParceraAvatarBase):
             asyncio.create_task(self.llm.warmup())
             
         logger.info(f"LLM reloaded: {type(self.llm).__name__}")
+
+    async def _broadcast_json(self, data: dict) -> None:
+        """Broadcast a JSON message to all real WebSocket clients (skip internal bridges)."""
+        for sid, ws in self.aiavatar_server.websockets.items():
+            if sid != TWITCH_SESSION_ID:
+                try:
+                    await ws.send_json(data)
+                except Exception:
+                    pass
 
     def _sync_to_server(self):
         """Update components and specific settings on the server instance (useful after hot-swapping)."""
@@ -291,14 +300,6 @@ async def lifespan(app: FastAPI):
     # Start MicAnalyzer for Python-side audio capture (STT + OBS lipsync broadcast)
     loop = asyncio.get_running_loop()
 
-    async def _broadcast_user_lipsync(event: dict) -> None:
-        for sid, ws in parcera_server.aiavatar_server.websockets.items():
-            if sid != TWITCH_SESSION_ID:
-                try:
-                    await ws.send_json(event)
-                except Exception:
-                    pass
-
     async def _handle_stt_audio(audio_data: bytes) -> None:
         try:
             result = await parcera_server.stt.recognize("parcera-mic-session", audio_data)
@@ -321,19 +322,14 @@ async def lifespan(app: FastAPI):
                 msg: dict = {"type": r.type, "text": r.text}
                 if r.audio_data:
                     msg["audio_data"] = base64.b64encode(r.audio_data).decode()
-                for sid, ws in parcera_server.aiavatar_server.websockets.items():
-                    if sid != TWITCH_SESSION_ID:
-                        try:
-                            await ws.send_json(msg)
-                        except Exception:
-                            pass
+                await parcera_server._broadcast_json(msg)
                 if r.type == "final":
                     await parcera_server.controller.on_response(_STSResponseAdapter(session_id), r)
         except Exception as e:
             logger.error(f"MicAnalyzer STT error: {e}", exc_info=True)
 
     mic = MicAnalyzer(loop)
-    mic.set_broadcast_callback(_broadcast_user_lipsync)
+    mic.set_broadcast_callback(parcera_server._broadcast_json)
     mic.set_stt_callback(_handle_stt_audio)
 
     vad_cfg = settings.get("vad", {})

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 import logging
 import os
 from dataclasses import dataclass
@@ -119,6 +120,7 @@ class ParceraServer(ParceraAvatarBase):
         self.current_stt_provider = self.config.get("stt", {}).get("provider", "faster_whisper")
         self.current_tts_provider = self.config.get("tts", {}).get("provider", "aivisspeech")
         self.current_llm_provider = self.config.get("llm", {}).get("provider", "gemini")
+        self.current_llm_hash = json.dumps(self.config.get("llm", {}), sort_keys=True)
 
         # Redirect all side-effect databases and files to writable directory
         db_path = os.path.join(self.config.app_data_dir, "aiavatar.db")
@@ -178,6 +180,7 @@ class ParceraServer(ParceraAvatarBase):
         self.llm = self.factory.build_llm()
         
         self.current_llm_provider = new_provider
+        self.current_llm_hash = json.dumps(self.config.get("llm", {}), sort_keys=True)
         self._sync_to_server()
         
         # Trigger warmup for local LLM
@@ -201,11 +204,31 @@ class ParceraServer(ParceraAvatarBase):
         if hasattr(self.llm, "system_prompt"):
             self.llm.system_prompt = self.config.full_system_prompt
 
+        vad_cfg = self.config.get("vad", {})
         if hasattr(self.vad, "volume_db_threshold"):
-            new_threshold = self.config.get("vad", {}).get("volume_db_threshold", -20.0)
+            new_threshold = vad_cfg.get("volume_db_threshold", -20.0)
             self.vad.volume_db_threshold = new_threshold
             if hasattr(self, "mic_analyzer") and self.mic_analyzer:
                 self.mic_analyzer.set_threshold_db(new_threshold)
+        if hasattr(self.vad, "silence_duration_threshold"):
+            self.vad.silence_duration_threshold = vad_cfg.get("silence_duration_threshold", 0.4)
+        if hasattr(self.vad, "max_duration"):
+            self.vad.max_duration = vad_cfg.get("max_duration", 15.0)
+
+        # merge_request_threshold (STS pipeline)
+        sts = getattr(self.aiavatar_server, "sts", None)
+        if sts and hasattr(sts, "merge_request_threshold"):
+            sts.merge_request_threshold = self.config.get("merge_request_threshold", 0.6)
+
+        # mic_device_id: restart MicAnalyzer only if device actually changed
+        if self.mic_analyzer:
+            new_device = self.config.get("app", {}).get("mic_device_id") or None
+            normalized = None if (not new_device or new_device == "default") else new_device
+            if normalized != self.mic_analyzer._mic_device:
+                logger.info(f"MicAnalyzer: device changed to {normalized!r}, restarting...")
+                self.mic_analyzer.stop()
+                self.mic_analyzer.set_mic_device(new_device)
+                self.mic_analyzer.start()
 
         # Update STT filters
         if hasattr(self.stt, "response_filter") and self.stt.response_filter:

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -26,6 +26,7 @@ from services.twitch_service import TwitchService
 from services.training_service import TrainingService
 
 from core.interaction import InteractionController
+from core.mic_analyzer import MicAnalyzer
 from core.constants import TWITCH_SESSION_ID, DEFAULT_UVICORN_PORT, DEFAULT_UVICORN_HOST
 
 logger = logging.getLogger(__name__)
@@ -66,6 +67,7 @@ class ParceraServer(ParceraAvatarBase):
         self.tts_engine_manager = None
         self._warmup_task: Optional[asyncio.Task] = None
         self._twitch_task: Optional[asyncio.Task] = None
+        self.mic_analyzer: Optional[MicAnalyzer] = None
 
         # Interaction Controller (Orchestrates the pipeline)
         self.controller = InteractionController(self, self.config)
@@ -255,9 +257,41 @@ async def lifespan(app: FastAPI):
     parcera_server._warmup_task = asyncio.create_task(parcera_server.warmup())
     parcera_server._twitch_task = asyncio.create_task(parcera_server.twitch_service.process_queue())
 
+    # Start MicAnalyzer for Python-side audio capture (STT + OBS lipsync broadcast)
+    loop = asyncio.get_event_loop()
+
+    async def _broadcast_user_lipsync(event: dict) -> None:
+        for sid, ws in parcera_server.aiavatar_server.websockets.items():
+            if sid != TWITCH_SESSION_ID:
+                try:
+                    await ws.send_json(event)
+                except Exception:
+                    pass
+
+    async def _handle_stt_audio(audio_data: bytes) -> None:
+        try:
+            result = await parcera_server.stt.recognize("parcera-mic-session", audio_data)
+            if result.text:
+                await parcera_server.controller.on_recognized("parcera-mic-session", result.text)
+        except Exception as e:
+            logger.error(f"MicAnalyzer STT error: {e}")
+
+    mic = MicAnalyzer(loop)
+    mic.set_broadcast_callback(_broadcast_user_lipsync)
+    mic.set_stt_callback(_handle_stt_audio)
+
+    settings = parcera_server.config.settings
+    vad_cfg = settings.get("vad", {})
+    mic.set_threshold_db(vad_cfg.get("volume_db_threshold", -25.0))
+    mic.set_mic_device(settings.get("app", {}).get("mic_device_id"))
+    mic.start()
+    parcera_server.mic_analyzer = mic
+
     yield
 
     # Shutdown
+    if parcera_server.mic_analyzer:
+        parcera_server.mic_analyzer.stop()
     if hasattr(parcera_server, '_warmup_task'): parcera_server._warmup_task.cancel()
     if hasattr(parcera_server, '_twitch_task'): parcera_server._twitch_task.cancel()
     await parcera_server.cleanup()

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -1,6 +1,8 @@
 import asyncio
+import base64
 import logging
 import os
+from dataclasses import dataclass
 
 # Suppress transformers "PyTorch was not found" warning (we use MLX, not PyTorch)
 os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
@@ -11,6 +13,7 @@ import httpx
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from aiavatar.adapter.websocket.server import AIAvatarWebSocketServer
+from aiavatar.sts.models import STSRequest
 from aiavatar.sts.session_state_manager import SQLiteSessionStateManager
 from aiavatar.sts.performance_recorder.sqlite import SQLitePerformanceRecorder
 from core.avatar import ParceraAvatarBase
@@ -28,6 +31,12 @@ from services.training_service import TrainingService
 from core.interaction import InteractionController
 from core.mic_analyzer import MicAnalyzer
 from core.constants import TWITCH_SESSION_ID, DEFAULT_UVICORN_PORT, DEFAULT_UVICORN_HOST
+
+
+@dataclass
+class _STSResponseAdapter:
+    """Minimal adapter satisfying InteractionController.on_response's aiavatar_response argument."""
+    session_id: str
 
 logger = logging.getLogger(__name__)
 
@@ -260,7 +269,7 @@ async def lifespan(app: FastAPI):
     parcera_server._twitch_task = asyncio.create_task(parcera_server.twitch_service.process_queue())
 
     # Start MicAnalyzer for Python-side audio capture (STT + OBS lipsync broadcast)
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
 
     async def _broadcast_user_lipsync(event: dict) -> None:
         for sid, ws in parcera_server.aiavatar_server.websockets.items():
@@ -281,23 +290,17 @@ async def lifespan(app: FastAPI):
 
             # Use the standard AI session so thinking/response signals reach the UI
             session_id = "parcera-session"
-            await parcera_server.controller.on_recognized(session_id, text)
+            accepted = await parcera_server.controller.on_recognized(session_id, text)
+            if not accepted:
+                return
 
             # Invoke STS pipeline (LLM → TTS) and broadcast each chunk to all UI clients
-            import base64 as _b64
-            from aiavatar.sts.models import STSRequest
-            from dataclasses import dataclass
-
-            @dataclass
-            class _MockResp:
-                session_id: str
-
             async for r in parcera_server.aiavatar_server.sts.invoke(
                 STSRequest(text=text, session_id=session_id)
             ):
                 msg: dict = {"type": r.type, "text": r.text}
                 if r.audio_data:
-                    msg["audio_data"] = _b64.b64encode(r.audio_data).decode()
+                    msg["audio_data"] = base64.b64encode(r.audio_data).decode()
                 for sid, ws in parcera_server.aiavatar_server.websockets.items():
                     if sid != TWITCH_SESSION_ID:
                         try:
@@ -305,7 +308,7 @@ async def lifespan(app: FastAPI):
                         except Exception:
                             pass
                 if r.type == "final":
-                    await parcera_server.controller.on_response(_MockResp(session_id), r)
+                    await parcera_server.controller.on_response(_STSResponseAdapter(session_id), r)
         except Exception as e:
             logger.error(f"MicAnalyzer STT error: {e}", exc_info=True)
 
@@ -313,9 +316,8 @@ async def lifespan(app: FastAPI):
     mic.set_broadcast_callback(_broadcast_user_lipsync)
     mic.set_stt_callback(_handle_stt_audio)
 
-    settings = parcera_server.config.settings
     vad_cfg = settings.get("vad", {})
-    mic.set_threshold_db(vad_cfg.get("volume_db_threshold", -25.0))
+    mic.set_threshold_db(vad_cfg.get("volume_db_threshold", -20.0))
     mic.set_mic_device(settings.get("app", {}).get("mic_device_id"))
     mic.start()
     parcera_server.mic_analyzer = mic

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -141,9 +141,9 @@ class ParceraServer(ParceraAvatarBase):
             voice_recorder_enabled=False
         )
 
-        # Attach callbacks to controller
-        if hasattr(self.stt, "on_recognized_callback"):
-            self.stt.on_recognized_callback = self.controller.on_recognized
+        # Attach response callback; STT recognition is handled exclusively by MicAnalyzer.
+        # Do NOT set on_recognized_callback here — stt.recognize() would call it internally,
+        # causing a double on_recognized invocation alongside the explicit call in _handle_stt_audio.
         self.aiavatar_server.on_response(self.controller.on_response)
 
         # Initial sync
@@ -188,9 +188,6 @@ class ParceraServer(ParceraAvatarBase):
 
     def _sync_to_server(self):
         """Update components and specific settings on the server instance (useful after hot-swapping)."""
-        if hasattr(self.stt, "on_recognized_callback"):
-            self.stt.on_recognized_callback = self.controller.on_recognized
-
         # Register/Ensure an internal bridge for Twitch responses
         self.aiavatar_server.websockets[TWITCH_SESSION_ID] = InternalWebSocket(self.aiavatar_server)
 

--- a/src/run_server.py
+++ b/src/run_server.py
@@ -198,6 +198,8 @@ class ParceraServer(ParceraAvatarBase):
         if hasattr(self.vad, "volume_db_threshold"):
             new_threshold = self.config.get("vad", {}).get("volume_db_threshold", -20.0)
             self.vad.volume_db_threshold = new_threshold
+            if hasattr(self, "mic_analyzer") and self.mic_analyzer:
+                self.mic_analyzer.set_threshold_db(new_threshold)
 
         # Update STT filters
         if hasattr(self.stt, "response_filter") and self.stt.response_filter:

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -77,6 +77,7 @@
   // ── Mutable state ────────────────────────────────────────────────────────────
   var settings       = {};
   var cacheKey       = 0;     // bumped on every applySettings; busts asset cache
+  var flipX          = 1;     // 1 = normal, -1 = horizontal flip
   var extLipsync     = null;   // user-avatar only: {env, rawAmplitude, vowel}
   var currentMouth   = 'base.png';
   var mouthHoldTimer = 0;
@@ -199,6 +200,8 @@
       img.classList.remove('chromakey');
     }
 
+    flipX = (avatarCfg && avatarCfg.flip_horizontal) ? -1 : 1;
+
     img.removeAttribute('style');
     img.src = assetsDir + '/base.png?v=' + cacheKey;
   }
@@ -287,7 +290,7 @@
     var norm    = wave / 1.5;
     var offsetY = (norm + 1) * 0.5 * bAmp;
     var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
-    img.style.transform = 'translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
+    img.style.transform = 'scaleX(' + flipX + ') translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
 
     // Lipsync state — source differs by avatar type
     var env, rmsRaw, vowel;

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -39,20 +39,19 @@
 (function () {
   // ── Port resolution ──────────────────────────────────────────────────────────
   // This page may be served from:
-  //   port 8676  — Python AI server (canonical OBS URL)
-  //   port 8677  — Tauri localhost plugin (fallback / dev workaround)
+  //   port 8676  — Python AI server (canonical OBS URL via file:// or http://)
+  //   port 8677  — Tauri localhost plugin (fallback)
   //   port 5173  — Vite dev server
-  // In all cases pythonPort = 8676 and frontendPort = 8677 (for Tauri assets).
-  var PYTHON_PORT   = 8676;
-  var FRONTEND_PORT = 8677;
+  // In all cases pythonPort resolves to 8676.
+  var PYTHON_PORT = 8676;
   var locPort = parseInt(location.port, 10);
-  var pythonPort, frontendPort;
+  var pythonPort;
   if (locPort === PYTHON_PORT || (locPort >= 5000 && locPort < 6000)) {
-    pythonPort   = PYTHON_PORT;
-    frontendPort = FRONTEND_PORT;
+    pythonPort = PYTHON_PORT;
   } else {
-    frontendPort = locPort || FRONTEND_PORT;
-    pythonPort   = frontendPort - 1;
+    // file:// → locPort=NaN → default to PYTHON_PORT+1-1=PYTHON_PORT
+    // Tauri (8677) → 8677-1=8676
+    pythonPort = (locPort || (PYTHON_PORT + 1)) - 1;
   }
 
   var p = new URLSearchParams(location.search);

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -43,11 +43,9 @@
   var locPort = parseInt(location.port, 10);
   var pythonPort, frontendPort;
   if (locPort === PYTHON_PORT || (locPort >= 5000 && locPort < 6000)) {
-    // Served from Python directly, or Vite dev — Python is on the known port.
     pythonPort   = PYTHON_PORT;
     frontendPort = FRONTEND_PORT;
   } else {
-    // Served from Tauri (8677 or custom): Python is one port below.
     frontendPort = locPort || FRONTEND_PORT;
     pythonPort   = frontendPort - 1;
   }
@@ -73,7 +71,7 @@
 
   // ── Mutable state ────────────────────────────────────────────────────────────
   var settings       = {};
-  var extLipsync     = null;
+  var extLipsync     = null;   // user-avatar only: {env, rawAmplitude, vowel}
   var currentMouth   = 'base.png';
   var mouthHoldTimer = 0;
   var isBlinking     = false;
@@ -83,6 +81,61 @@
 
   var img = document.getElementById('avatar');
   var dbg = document.getElementById('dbg');
+
+  // ── AI audio playback (type=ai only) ─────────────────────────────────────────
+  var audioCtx     = null;
+  var aiAnalyser   = null;
+  var aiTimeBuf    = null;
+  var audioQueue   = [];
+  var isAIPlaying  = false;
+
+  function initAudioCtx() {
+    if (audioCtx) return;
+    audioCtx   = new AudioContext();
+    aiAnalyser = audioCtx.createAnalyser();
+    aiAnalyser.fftSize = 256;
+    aiTimeBuf  = new Uint8Array(aiAnalyser.frequencyBinCount);
+    aiAnalyser.connect(audioCtx.destination);
+    if (audioCtx.state === 'suspended') audioCtx.resume().catch(function () {});
+  }
+
+  function getAIRms() {
+    if (!aiAnalyser || !aiTimeBuf) return 0;
+    aiAnalyser.getByteTimeDomainData(aiTimeBuf);
+    var sum = 0;
+    for (var i = 0; i < aiTimeBuf.length; i++) {
+      var v = (aiTimeBuf[i] - 128) / 128;
+      sum += v * v;
+    }
+    return Math.sqrt(sum / aiTimeBuf.length);
+  }
+
+  function playNextChunk() {
+    if (audioQueue.length === 0) { isAIPlaying = false; return; }
+    isAIPlaying = true;
+    var b64 = audioQueue.shift();
+    var raw = atob(b64);
+    var buf = new Uint8Array(raw.length);
+    for (var i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+    audioCtx.decodeAudioData(buf.buffer, function (decoded) {
+      var src = audioCtx.createBufferSource();
+      src.buffer = decoded;
+      src.connect(aiAnalyser);
+      src.onended = playNextChunk;
+      src.start();
+    }, function () { playNextChunk(); });
+  }
+
+  function enqueueAIChunk(b64) {
+    initAudioCtx();
+    audioQueue.push(b64);
+    if (!isAIPlaying) playNextChunk();
+  }
+
+  function flushAIQueue() {
+    audioQueue.length = 0;
+    isAIPlaying = false;
+  }
 
   // ── Settings ─────────────────────────────────────────────────────────────────
   function applySettings(s) {
@@ -120,7 +173,8 @@
 
   // ── WebSocket ────────────────────────────────────────────────────────────────
   var ws;
-  var wsSessionId = 'lipsync-' + Math.random().toString(36).slice(2, 9);
+  var wsSessionId = (avatarType === 'ai' ? 'obs-ai-' : 'obs-user-') +
+                    Math.random().toString(36).slice(2, 9);
 
   function connectWS() {
     ws = new WebSocket(wsUrl);
@@ -133,19 +187,33 @@
     ws.onmessage = function (e) {
       try {
         var d = JSON.parse(e.data);
-        if (d.type === 'user_lipsync') {
-          var vowel    = d.vowel || null;
-          var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
-          var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
-          extLipsync   = {
-            env:          speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
-            rawAmplitude: amp,
-            vowel:        vowel
-          };
+        if (avatarType === 'ai') {
+          // AI avatar: play TTS audio chunks received from the server.
+          if (d.type === 'start' || d.type === 'thinking') {
+            flushAIQueue();
+          } else if (d.type === 'chunk' && d.audio_data) {
+            enqueueAIChunk(d.audio_data);
+          }
+        } else {
+          // User avatar: animate mouth from Python MicAnalyzer lipsync events.
+          if (d.type === 'user_lipsync') {
+            var vowel    = d.vowel || null;
+            var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
+            var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
+            extLipsync   = {
+              env:          speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
+              rawAmplitude: amp,
+              vowel:        vowel
+            };
+          }
         }
       } catch (_) {}
     };
-    ws.onclose  = function () { extLipsync = null; setTimeout(connectWS, 3000); };
+    ws.onclose  = function () {
+      extLipsync = null;
+      flushAIQueue();
+      setTimeout(connectWS, 3000);
+    };
     ws.onerror  = function () {};
   }
 
@@ -166,11 +234,20 @@
     var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
     img.style.transform = 'translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
 
-    // Lipsync state
-    var env    = extLipsync ? extLipsync.env          : 0;
-    var rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;
-    var vowel  = (extLipsync && extLipsync.env > TALK_THRESHOLD)
-      ? (extLipsync.vowel || '-') : '-';
+    // Lipsync state — source differs by avatar type
+    var env, rmsRaw, vowel;
+    if (avatarType === 'ai') {
+      // Derive lipsync from WebAudio analyser (TTS playback amplitude).
+      rmsRaw = getAIRms();
+      env    = rmsRaw;
+      // Simple open/close: no per-vowel detection for synthetic TTS audio.
+      vowel  = env > TALK_THRESHOLD ? 'a' : '-';
+    } else {
+      env    = extLipsync ? extLipsync.env          : 0;
+      rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;
+      vowel  = (extLipsync && extLipsync.env > TALK_THRESHOLD)
+        ? (extLipsync.vowel || '-') : '-';
+    }
 
     // Debug overlay
     if (!dbg.hidden) {

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -83,9 +83,17 @@
   var dbg = document.getElementById('dbg');
 
   // ── AI audio playback (type=ai only) ─────────────────────────────────────────
+  // Mirror of audio.ts constants for spectral-centroid vowel detection.
+  var AI_FFT_SIZE             = 512;
+  var AI_SMOOTHING            = 0.2;
+  var AI_LOW_FREQ_CUTOFF      = 200;   // Hz — ignore rumble below this
+  var AI_SILENCE_AMP_FLOOR    = 0.001;
+  var AI_VOWEL_HZ             = { u: 600, o: 1500, a: 3000, e: 5000 };
+
   var audioCtx     = null;
   var aiAnalyser   = null;
-  var aiTimeBuf    = null;
+  var aiTimeBuf    = null;   // Float32Array(fftSize) for RMS
+  var aiFreqBuf    = null;   // Float32Array(frequencyBinCount) for vowel
   var audioQueue   = [];
   var isAIPlaying  = false;
 
@@ -93,21 +101,41 @@
     if (audioCtx) return;
     audioCtx   = new AudioContext();
     aiAnalyser = audioCtx.createAnalyser();
-    aiAnalyser.fftSize = 256;
-    aiTimeBuf  = new Uint8Array(aiAnalyser.frequencyBinCount);
+    aiAnalyser.fftSize                = AI_FFT_SIZE;
+    aiAnalyser.smoothingTimeConstant  = AI_SMOOTHING;
+    aiTimeBuf  = new Float32Array(AI_FFT_SIZE);
+    aiFreqBuf  = new Float32Array(aiAnalyser.frequencyBinCount);
     aiAnalyser.connect(audioCtx.destination);
     if (audioCtx.state === 'suspended') audioCtx.resume().catch(function () {});
   }
 
   function getAIRms() {
     if (!aiAnalyser || !aiTimeBuf) return 0;
-    aiAnalyser.getByteTimeDomainData(aiTimeBuf);
+    aiAnalyser.getFloatTimeDomainData(aiTimeBuf);
     var sum = 0;
-    for (var i = 0; i < aiTimeBuf.length; i++) {
-      var v = (aiTimeBuf[i] - 128) / 128;
-      sum += v * v;
-    }
+    for (var i = 0; i < aiTimeBuf.length; i++) sum += aiTimeBuf[i] * aiTimeBuf[i];
     return Math.sqrt(sum / aiTimeBuf.length);
+  }
+
+  function getAIVowel() {
+    if (!aiAnalyser || !aiFreqBuf) return null;
+    aiAnalyser.getFloatFrequencyData(aiFreqBuf);
+    var nyquist = audioCtx.sampleRate / 2;
+    var weightedSum = 0, totalAmp = 0;
+    for (var i = 0; i < aiFreqBuf.length; i++) {
+      var hz = (i / aiFreqBuf.length) * nyquist;
+      if (hz <= AI_LOW_FREQ_CUTOFF) continue;
+      var amp = Math.pow(10, aiFreqBuf[i] / 20); // dB → linear
+      weightedSum += amp * hz;
+      totalAmp    += amp;
+    }
+    if (totalAmp < AI_SILENCE_AMP_FLOOR) return null;
+    var centroid = weightedSum / totalAmp;
+    if (centroid < AI_VOWEL_HZ.u) return 'u';
+    if (centroid < AI_VOWEL_HZ.o) return 'o';
+    if (centroid < AI_VOWEL_HZ.a) return 'a';
+    if (centroid < AI_VOWEL_HZ.e) return 'e';
+    return 'i';
   }
 
   function playNextChunk() {
@@ -237,11 +265,12 @@
     // Lipsync state — source differs by avatar type
     var env, rmsRaw, vowel;
     if (avatarType === 'ai') {
-      // Derive lipsync from WebAudio analyser (TTS playback amplitude).
+      // Derive lipsync from WebAudio analyser (TTS playback).
+      // Mirrors audio.ts: spectral-centroid vowel detection on the live PCM stream.
       rmsRaw = getAIRms();
       env    = rmsRaw;
-      // Simple open/close: no per-vowel detection for synthetic TTS audio.
-      vowel  = env > TALK_THRESHOLD ? 'a' : '-';
+      var aiVowel = getAIVowel();
+      vowel  = (env > TALK_THRESHOLD && aiVowel) ? aiVowel : '-';
     } else {
       env    = extLipsync ? extLipsync.env          : 0;
       rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -71,6 +71,7 @@
 
   // ── Mutable state ────────────────────────────────────────────────────────────
   var settings       = {};
+  var cacheKey       = 0;     // bumped on every applySettings; busts asset cache
   var extLipsync     = null;   // user-avatar only: {env, rawAmplitude, vowel}
   var currentMouth   = 'base.png';
   var mouthHoldTimer = 0;
@@ -168,12 +169,22 @@
   // ── Settings ─────────────────────────────────────────────────────────────────
   function applySettings(s) {
     settings = s;
-    // assetsDir always points to the Python proxy (/config/obs-asset/{type}).
-    // Python resolves the actual filesystem path (custom or bundled) server-side,
-    // so obs.html never needs file:// URLs (blocked from http:// pages in Chromium).
+    // Bump cacheKey so every asset URL gets a fresh ?v= param.
+    // This forces the browser to re-fetch sprites when assets_dir changes.
+    cacheKey = Date.now();
+
     dbg.hidden = !(s.avatars && s.avatars.show_debug !== false);
+
+    // Chroma key background (mirrors Tauri avatar window behaviour).
+    var avatarCfg = s.avatars && s.avatars[avatarType];
+    if (avatarCfg && avatarCfg.chroma_key_enabled) {
+      document.body.style.background = avatarCfg.chroma_key_color || 'green';
+    } else {
+      document.body.style.background = 'transparent';
+    }
+
     img.removeAttribute('style');
-    img.src = assetsDir + '/base.png';
+    img.src = assetsDir + '/base.png?v=' + cacheKey;
   }
 
   function fetchSettings() {
@@ -332,8 +343,8 @@
       target = currentMouth;
     }
 
-    // Apply image
-    var newSrc = assetsDir + '/' + target;
+    // Apply image (include cacheKey so asset changes propagate after config reload)
+    var newSrc = assetsDir + '/' + target + '?v=' + cacheKey;
     var absNew = new URL(newSrc, location.href).href;
     if (img.src !== absNew) {
       img.src = newSrc;
@@ -342,7 +353,7 @@
           currentMouth   = 'base.png';
           mouthHoldTimer = 0;
         }
-        img.src     = assetsDir + '/base.png';
+        img.src     = assetsDir + '/base.png?v=' + cacheKey;
         img.onerror = null;
       };
     }

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: transparent; overflow: hidden; }
+    #avatar {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: top left;
+      transform-origin: top center;
+      pointer-events: none;
+      display: block;
+    }
+    #dbg {
+      position: fixed;
+      bottom: 4px;
+      left: 4px;
+      background: rgba(0,0,0,.75);
+      color: #fff;
+      font: 11px/1.4 monospace;
+      padding: 2px 4px;
+      border-radius: 2px;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <img id="avatar" alt="">
+  <div id="dbg" hidden></div>
+<script>
+(function () {
+  // ── Port resolution ──────────────────────────────────────────────────────────
+  // This page may be served from:
+  //   port 8676  — Python AI server (canonical OBS URL)
+  //   port 8677  — Tauri localhost plugin (fallback / dev workaround)
+  //   port 5173  — Vite dev server
+  // In all cases pythonPort = 8676 and frontendPort = 8677 (for Tauri assets).
+  var PYTHON_PORT   = 8676;
+  var FRONTEND_PORT = 8677;
+  var locPort = parseInt(location.port, 10);
+  var pythonPort, frontendPort;
+  if (locPort === PYTHON_PORT || (locPort >= 5000 && locPort < 6000)) {
+    // Served from Python directly, or Vite dev — Python is on the known port.
+    pythonPort   = PYTHON_PORT;
+    frontendPort = FRONTEND_PORT;
+  } else {
+    // Served from Tauri (8677 or custom): Python is one port below.
+    frontendPort = locPort || FRONTEND_PORT;
+    pythonPort   = frontendPort - 1;
+  }
+
+  var p = new URLSearchParams(location.search);
+  var avatarType  = p.get('type') || 'user';
+  var pythonHttp  = 'http://127.0.0.1:' + pythonPort;
+  var wsUrl       = 'ws://127.0.0.1:' + pythonPort + '/ws';
+  // Default bundled assets come from the Tauri static server.
+  var assetsDir   = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
+
+  // ── Constants ────────────────────────────────────────────────────────────────
+  var TALK_THRESHOLD     = 0.05;
+  var BLINK_CLOSE_MS     = 150;
+  var DEFAULT_BLINK_MIN  = 5000;
+  var DEFAULT_BLINK_MAX  = 15000;
+  var DEFAULT_MOUTH_HOLD = 120;
+  var DB_FLOOR           = -55;
+  var DB_CEIL            = -5;
+  var METER_SIZE         = 15;
+  var VOWEL_OVERRIDE     = { n: 'base.png' };
+
+  // ── Mutable state ────────────────────────────────────────────────────────────
+  var settings       = {};
+  var extLipsync     = null;
+  var currentMouth   = 'base.png';
+  var mouthHoldTimer = 0;
+  var isBlinking     = false;
+  var blinkTimer     = Date.now() + 2000;
+  var breatheTime    = Math.random() * 100;
+  var lastFrameTime  = performance.now();
+
+  var img = document.getElementById('avatar');
+  var dbg = document.getElementById('dbg');
+
+  // ── Settings ─────────────────────────────────────────────────────────────────
+  function applySettings(s) {
+    settings = s;
+    var avatarCfg = s.avatars && s.avatars[avatarType];
+    if (typeof avatarCfg === 'object' && avatarCfg && avatarCfg.assets_dir) {
+      assetsDir = 'file://' + avatarCfg.assets_dir;
+    } else {
+      assetsDir = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
+    }
+    dbg.hidden = !(s.avatars && s.avatars.show_debug !== false);
+    if (img.src !== assetsDir + '/base.png') {
+      img.removeAttribute('style');
+      img.src = assetsDir + '/base.png';
+    }
+  }
+
+  function fetchSettings() {
+    fetch(pythonHttp + '/config/settings', { cache: 'no-store' })
+      .then(function (r) { return r.json(); })
+      .then(applySettings)
+      .catch(function () { setTimeout(fetchSettings, 3000); });
+  }
+
+  // ── Image error recovery ─────────────────────────────────────────────────────
+  img.addEventListener('error', function () {
+    var src = img.src;
+    if (src.endsWith('/e.png')) {
+      img.src = src.replace('/e.png', '/a.png');
+    } else if (src.endsWith('/o.png')) {
+      img.src = src.replace('/o.png', '/u.png');
+    } else if (!src.endsWith('/base.png')) {
+      currentMouth   = 'base.png';
+      mouthHoldTimer = 0;
+      img.src = assetsDir + '/base.png';
+    } else {
+      img.style.opacity = '0.5';
+    }
+  });
+
+  // ── WebSocket ────────────────────────────────────────────────────────────────
+  var ws;
+  var wsSessionId = 'lipsync-' + Math.random().toString(36).slice(2, 9);
+
+  function connectWS() {
+    ws = new WebSocket(wsUrl);
+    ws.onopen = function () {
+      ws.send(JSON.stringify({ type: 'start', session_id: wsSessionId }));
+      // Re-fetch settings on every (re)connect so Parcera restarts pick up
+      // config changes without a manual OBS refresh.
+      fetchSettings();
+    };
+    ws.onmessage = function (e) {
+      try {
+        var d = JSON.parse(e.data);
+        if (d.type === 'user_lipsync') {
+          var vowel    = d.vowel || null;
+          var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
+          var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
+          extLipsync   = {
+            env:          speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
+            rawAmplitude: amp,
+            vowel:        vowel
+          };
+        }
+      } catch (_) {}
+    };
+    ws.onclose  = function () { extLipsync = null; setTimeout(connectWS, 3000); };
+    ws.onerror  = function () {};
+  }
+
+  // ── Animation loop ───────────────────────────────────────────────────────────
+  function frame() {
+    var now = performance.now();
+    var dt  = (now - lastFrameTime) / 1000;
+    lastFrameTime = now;
+
+    // Breathing
+    var bDur   = (settings.avatars && settings.avatars.breathe_duration)  || 5000;
+    var bScale = (settings.avatars && settings.avatars.breathe_scale)     || 1.005;
+    var bAmp   = (settings.avatars && settings.avatars.breathe_amplitude) || 2;
+    breatheTime += dt * (2 * Math.PI) / (bDur / 1000);
+    var wave    = Math.sin(breatheTime) + 0.5 * Math.sin(breatheTime * 1.618);
+    var norm    = wave / 1.5;
+    var offsetY = (norm + 1) * 0.5 * bAmp;
+    var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
+    img.style.transform = 'translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
+
+    // Lipsync state
+    var env    = extLipsync ? extLipsync.env          : 0;
+    var rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;
+    var vowel  = (extLipsync && extLipsync.env > TALK_THRESHOLD)
+      ? (extLipsync.vowel || '-') : '-';
+
+    // Debug overlay
+    if (!dbg.hidden) {
+      var db   = 20 * Math.log10(Math.max(rmsRaw, 0.00001));
+      var span = DB_CEIL - DB_FLOOR;
+      var on   = Math.floor(Math.max(0, Math.min(1, (db - DB_FLOOR) / span)) * METER_SIZE);
+      var tDb  = (settings.vad && settings.vad.volume_db_threshold) || -20;
+      var tPos = Math.floor(Math.max(0, Math.min(1, (tDb - DB_FLOOR) / span)) * METER_SIZE);
+      var meter = '';
+      for (var i = 0; i < METER_SIZE; i++) {
+        if (i === tPos) {
+          meter += '<span style="color:#ff0;font-weight:bold">|</span>';
+        } else if (i < on) {
+          var col = db >= DB_CEIL ? '#f44' : env > TALK_THRESHOLD ? '#4f4' : '#999';
+          meter += '<span style="color:' + col + '">█</span>';
+        } else {
+          meter += '<span style="color:#444">░</span>';
+        }
+      }
+      dbg.innerHTML = '[' + meter + '] ' + db.toFixed(1) + 'dB | Env:' + (env * 100).toFixed(0) + '% | Vowel:' + vowel;
+    }
+
+    // Blink
+    var nowMs  = Date.now();
+    var minBl  = (settings.avatars && settings.avatars.blink_interval_min) || DEFAULT_BLINK_MIN;
+    var maxBl  = (settings.avatars && settings.avatars.blink_interval_max) || DEFAULT_BLINK_MAX;
+    var holdMs = (settings.avatars && settings.avatars.mouth_hold_time)    || DEFAULT_MOUTH_HOLD;
+    var target = 'base.png';
+
+    if (nowMs > blinkTimer) {
+      if (!isBlinking) {
+        isBlinking = true;
+        blinkTimer = nowMs + BLINK_CLOSE_MS;
+      } else {
+        isBlinking = false;
+        blinkTimer = nowMs + minBl + Math.random() * (maxBl - minBl);
+      }
+    }
+
+    if (isBlinking) {
+      target = 'closed.png';
+    } else {
+      if (nowMs > mouthHoldTimer) {
+        var next = 'base.png';
+        if (env > TALK_THRESHOLD && vowel && vowel !== '?' && vowel !== '-') {
+          next = VOWEL_OVERRIDE[vowel] || (vowel + '.png');
+        }
+        if (next !== currentMouth) {
+          currentMouth   = next;
+          mouthHoldTimer = nowMs + holdMs;
+        }
+      }
+      target = currentMouth;
+    }
+
+    // Apply image
+    var newSrc = assetsDir + '/' + target;
+    var absNew = new URL(newSrc, location.href).href;
+    if (img.src !== absNew) {
+      img.src = newSrc;
+      img.onerror = function () {
+        if (target !== 'base.png' && target !== 'closed.png') {
+          currentMouth   = 'base.png';
+          mouthHoldTimer = 0;
+        }
+        img.src     = assetsDir + '/base.png';
+        img.onerror = null;
+      };
+    }
+
+    if (document.hidden) { setTimeout(frame, 33); } else { requestAnimationFrame(frame); }
+  }
+
+  // ── Boot ─────────────────────────────────────────────────────────────────────
+  fetchSettings();
+  connectWS();
+  requestAnimationFrame(frame);
+})();
+</script>
+</body>
+</html>

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -25,11 +25,16 @@
       border-radius: 2px;
       pointer-events: none;
     }
+    #avatar.chromakey { filter: url(#chromakey-filter); }
   </style>
 </head>
 <body>
   <img id="avatar" alt="">
   <div id="dbg" hidden></div>
+  <!-- SVG chroma key filter — mirrors ChromaKeyFilter.tsx (feColorMatrix alpha extraction) -->
+  <svg width="0" height="0" style="position:absolute;pointer-events:none">
+    <defs><filter id="chromakey-filter"></filter></defs>
+  </svg>
 <script>
 (function () {
   // ── Port resolution ──────────────────────────────────────────────────────────
@@ -174,6 +179,25 @@
     cacheKey = Date.now();
 
     dbg.hidden = !(s.avatars && s.avatars.show_debug !== false);
+
+    // Chroma key: SVG feColorMatrix filter, same logic as ChromaKeyFilter.tsx.
+    var avatarCfg = s.avatars && s.avatars[avatarType];
+    var chromaEnabled = !!(avatarCfg && avatarCfg.chroma_key_enabled);
+    var chromaColor   = (avatarCfg && avatarCfg.chroma_key_color) || 'green';
+    var filterEl = document.getElementById('chromakey-filter');
+    if (chromaEnabled) {
+      var m = chromaColor === 'green'
+        ? '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  3.0 -6.0 3.0 1.0 0.5'
+        : '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  3.0 3.0 -6.0 1.0 0.5';
+      filterEl.setAttribute('color-interpolation-filters', 'sRGB');
+      filterEl.innerHTML = '<feColorMatrix type="matrix" values="' + m + '"/>'
+        + '<feComponentTransfer><feFuncA type="table" tableValues="0 1"/></feComponentTransfer>';
+      img.classList.add('chromakey');
+    } else {
+      filterEl.removeAttribute('color-interpolation-filters');
+      filterEl.innerHTML = '<feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>';
+      img.classList.remove('chromakey');
+    }
 
     img.removeAttribute('style');
     img.src = assetsDir + '/base.png?v=' + cacheKey;

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -56,8 +56,9 @@
   var avatarType  = p.get('type') || 'user';
   var pythonHttp  = 'http://127.0.0.1:' + pythonPort;
   var wsUrl       = 'ws://127.0.0.1:' + pythonPort + '/ws';
-  // Default bundled assets come from the Tauri static server.
-  var assetsDir   = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
+  // Images are always served via the Python proxy so obs.html (an http:// page)
+  // can load them without hitting the browser's file:// mixed-content block.
+  var assetsDir   = pythonHttp + '/config/obs-asset/' + avatarType;
 
   // ── Constants ────────────────────────────────────────────────────────────────
   var TALK_THRESHOLD     = 0.05;
@@ -86,17 +87,12 @@
   // ── Settings ─────────────────────────────────────────────────────────────────
   function applySettings(s) {
     settings = s;
-    var avatarCfg = s.avatars && s.avatars[avatarType];
-    if (typeof avatarCfg === 'object' && avatarCfg && avatarCfg.assets_dir) {
-      assetsDir = 'file://' + avatarCfg.assets_dir;
-    } else {
-      assetsDir = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
-    }
+    // assetsDir always points to the Python proxy (/config/obs-asset/{type}).
+    // Python resolves the actual filesystem path (custom or bundled) server-side,
+    // so obs.html never needs file:// URLs (blocked from http:// pages in Chromium).
     dbg.hidden = !(s.avatars && s.avatars.show_debug !== false);
-    if (img.src !== assetsDir + '/base.png') {
-      img.removeAttribute('style');
-      img.src = assetsDir + '/base.png';
-    }
+    img.removeAttribute('style');
+    img.src = assetsDir + '/base.png';
   }
 
   function fetchSettings() {

--- a/src/static/obs.html
+++ b/src/static/obs.html
@@ -175,14 +175,6 @@
 
     dbg.hidden = !(s.avatars && s.avatars.show_debug !== false);
 
-    // Chroma key background (mirrors Tauri avatar window behaviour).
-    var avatarCfg = s.avatars && s.avatars[avatarType];
-    if (avatarCfg && avatarCfg.chroma_key_enabled) {
-      document.body.style.background = avatarCfg.chroma_key_color || 'green';
-    } else {
-      document.body.style.background = 'transparent';
-    }
-
     img.removeAttribute('style');
     img.src = assetsDir + '/base.png?v=' + cacheKey;
   }

--- a/tests/test_config_router_security.py
+++ b/tests/test_config_router_security.py
@@ -1,0 +1,88 @@
+"""Security tests for /config/obs-asset endpoint."""
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from fastapi import FastAPI
+from routers.config_router import create_config_router
+
+
+def _make_client(assets_dir: Path | None = None):
+    """Create a test client with a mock server whose assets_dir is set."""
+    mock_server = MagicMock()
+    mock_server.config.get.return_value = {}
+
+    if assets_dir is not None:
+        mock_server.config.get.return_value = {
+            "user": {"assets_dir": str(assets_dir)},
+            "ai": {"assets_dir": str(assets_dir)},
+        }
+
+    app = FastAPI()
+    router = create_config_router(lambda: mock_server)
+    app.include_router(router)
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_invalid_avatar_type_returns_404(tmp_path):
+    """Unrecognized avatar_type values must be rejected before any filesystem access."""
+    client = _make_client()
+    response = client.get("/config/obs-asset/../../etc/passwd/base.png")
+    assert response.status_code == 404
+
+def test_unknown_avatar_type_string_returns_404(tmp_path):
+    """Arbitrary strings like 'admin' or 'system' are not valid avatar types."""
+    client = _make_client()
+    for bad_type in ("admin", "system", "root", "../user", "."):
+        response = client.get(f"/config/obs-asset/{bad_type}/base.png")
+        assert response.status_code == 404, f"Expected 404 for avatar_type={bad_type!r}"
+
+def test_valid_avatar_type_with_missing_file_returns_404(tmp_path):
+    """Valid type and real assets dir, but requested file does not exist → 404."""
+    assets = tmp_path / "user"
+    assets.mkdir()
+    # No files created — directory exists but is empty
+
+    mock_server = MagicMock()
+    mock_server.config.get.return_value = {"user": {"assets_dir": str(assets)}}
+
+    app = FastAPI()
+    router = create_config_router(lambda: mock_server)
+    app.include_router(router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/config/obs-asset/user/nonexistent.png")
+    assert response.status_code == 404
+
+def test_valid_avatar_type_serves_file(tmp_path):
+    """Valid type with a real assets dir and file → 200."""
+    assets = tmp_path / "user"
+    assets.mkdir()
+    (assets / "base.png").write_bytes(b"\x89PNG\r\n")
+
+    mock_server = MagicMock()
+    mock_server.config.get.return_value = {"user": {"assets_dir": str(assets)}}
+
+    app = FastAPI()
+    router = create_config_router(lambda: mock_server)
+    app.include_router(router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/config/obs-asset/user/base.png")
+    assert response.status_code == 200
+
+def test_path_traversal_in_filename_returns_403(tmp_path):
+    """../secret in filename must be blocked by the existing traversal guard."""
+    assets = tmp_path / "user"
+    assets.mkdir()
+
+    mock_server = MagicMock()
+    mock_server.config.get.return_value = {"user": {"assets_dir": str(assets)}}
+
+    app = FastAPI()
+    router = create_config_router(lambda: mock_server)
+    app.include_router(router)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/config/obs-asset/user/..%2F..%2Fetc%2Fpasswd")
+    assert response.status_code in (403, 404)

--- a/tests/test_config_router_security.py
+++ b/tests/test_config_router_security.py
@@ -1,4 +1,5 @@
-"""Security tests for /config/obs-asset endpoint."""
+"""Security tests for /config/obs-asset and /config/settings endpoints."""
+import json
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -70,6 +71,69 @@ def test_valid_avatar_type_serves_file(tmp_path):
 
     response = client.get("/config/obs-asset/user/base.png")
     assert response.status_code == 200
+
+def _make_full_settings_client(settings: dict):
+    mock_server = MagicMock()
+    mock_server.config.settings = settings
+    app = FastAPI()
+    router = create_config_router(lambda: mock_server)
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_get_settings_does_not_leak_llm_api_keys():
+    """GET /config/settings must not expose LLM provider API keys."""
+    client = _make_full_settings_client({
+        "llm": {
+            "provider": "gemini",
+            "providers": {
+                "gemini": {"api_key": "SECRET_GEMINI", "model": "gemini-pro"},
+                "openai": {"api_key": "SECRET_OPENAI", "model": "gpt-4o"},
+            },
+        },
+        "avatars": {"show_debug": False},
+    })
+    data = json.dumps(client.get("/config/settings").json())
+    assert "SECRET_GEMINI" not in data
+    assert "SECRET_OPENAI" not in data
+    assert "gemini-pro" in data  # non-sensitive fields preserved
+
+
+def test_get_settings_does_not_leak_stt_tts_api_keys():
+    """GET /config/settings must not expose STT/TTS provider API keys."""
+    client = _make_full_settings_client({
+        "stt": {"provider": "google", "providers": {"google": {"api_key": "STT_SECRET"}}},
+        "tts": {"providers": {"google": {"api_key": "TTS_SECRET"}}},
+    })
+    data = json.dumps(client.get("/config/settings").json())
+    assert "STT_SECRET" not in data
+    assert "TTS_SECRET" not in data
+
+
+def test_get_settings_strips_twitch_credentials():
+    """GET /config/settings must not expose Twitch client_id or client_secret."""
+    client = _make_full_settings_client({
+        "twitch": {"client_id": "TWITCH_ID", "client_secret": "TWITCH_SECRET", "enabled": True},
+        "avatars": {"show_debug": False},
+    })
+    data = json.dumps(client.get("/config/settings").json())
+    assert "TWITCH_ID" not in data
+    assert "TWITCH_SECRET" not in data
+
+
+def test_get_settings_returns_200_with_display_fields():
+    """GET /config/settings returns 200 and preserves display-safe fields."""
+    client = _make_full_settings_client({
+        "avatars": {"show_debug": True, "blink_interval_min": 3.0},
+        "vad": {"volume_db_threshold": -25.0},
+        "app": {"port": 8676},
+    })
+    resp = client.get("/config/settings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("avatars", {}).get("show_debug") is True
+    assert body.get("vad", {}).get("volume_db_threshold") == -25.0
+
 
 def test_path_traversal_in_filename_returns_403(tmp_path):
     """../secret in filename must be blocked by the existing traversal guard."""

--- a/tests/test_interaction_priority.py
+++ b/tests/test_interaction_priority.py
@@ -32,6 +32,41 @@ async def test_on_recognized_drops_when_twitch_busy(mock_avatar, mock_config):
     mock_avatar.set_busy.assert_called_once_with("session", False)
 
 @pytest.mark.anyio
+async def test_on_recognized_returns_false_when_twitch_busy(mock_avatar, mock_config):
+    controller = InteractionController(mock_avatar, mock_config)
+    mock_avatar.is_busy.side_effect = lambda source=None: source == "twitch"
+
+    result = await controller.on_recognized("session", "Hello")
+
+    assert result is False
+
+@pytest.mark.anyio
+async def test_on_recognized_returns_false_when_training_busy(mock_avatar, mock_config):
+    controller = InteractionController(mock_avatar, mock_config)
+    mock_avatar.is_busy.side_effect = lambda source=None: source == "training"
+
+    result = await controller.on_recognized("session", "Hello")
+
+    assert result is False
+
+@pytest.mark.anyio
+async def test_on_recognized_returns_false_when_is_filtered(mock_avatar, mock_config):
+    controller = InteractionController(mock_avatar, mock_config)
+
+    result = await controller.on_recognized("session", "ignored text", is_filtered=True)
+
+    assert result is False
+
+@pytest.mark.anyio
+async def test_on_recognized_returns_true_when_approved(mock_avatar, mock_config):
+    controller = InteractionController(mock_avatar, mock_config)
+    mock_avatar.is_busy.return_value = False
+
+    result = await controller.on_recognized("session", "Hello there")
+
+    assert result is True
+
+@pytest.mark.anyio
 async def test_on_response_sets_source_correctly(mock_avatar, mock_config):
     mock_config.get.return_value = {"chars_per_second": 6.0, "buffer_latency": 1.0}
     controller = InteractionController(mock_avatar, mock_config)

--- a/tests/test_mic_analyzer.py
+++ b/tests/test_mic_analyzer.py
@@ -19,6 +19,8 @@ def mic():
     loop = asyncio.new_event_loop()
     m = MicAnalyzer(loop)
     m._threshold_db = -35.0
+    from unittest.mock import MagicMock
+    m.set_stt_callback(MagicMock())
     yield m
     loop.close()
 
@@ -34,9 +36,6 @@ def drive(mic: MicAnalyzer, chunk: np.ndarray, count: int) -> None:
 class TestEarlyFlush:
     def test_early_flush_resets_is_speaking(self, mic):
         """_is_speaking must be False after MAX_SPEECH_CHUNKS triggers an early flush."""
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
-
         loud = _make_chunk(-20)
         drive(mic, loud, MAX_SPEECH_CHUNKS)
 
@@ -44,9 +43,6 @@ class TestEarlyFlush:
 
     def test_early_flush_clears_vad_buffer(self, mic):
         """_vad_buffer must be empty after early flush."""
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
-
         loud = _make_chunk(-20)
         drive(mic, loud, MAX_SPEECH_CHUNKS)
 
@@ -54,9 +50,6 @@ class TestEarlyFlush:
 
     def test_early_flush_resets_speech_chunk_count(self, mic):
         """_speech_chunk_count must be zero after early flush."""
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
-
         loud = _make_chunk(-20)
         drive(mic, loud, MAX_SPEECH_CHUNKS)
 
@@ -64,33 +57,22 @@ class TestEarlyFlush:
 
     def test_next_utterance_not_discarded_after_early_flush(self, mic):
         """Silence after an early flush must not trigger a spurious MIN_SPEECH_CHUNKS rejection."""
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
-
         loud = _make_chunk(-20)
         silent = _make_chunk(-70)
 
-        # Early flush
         drive(mic, loud, MAX_SPEECH_CHUNKS)
-        # One silent chunk — should NOT immediately commit a 0-speech-chunk utterance
         drive(mic, silent, 1)
 
-        # After the single silence, is_speaking should still be False (no new speech)
         assert mic._is_speaking is False
 
 
 class TestNormalVADFlow:
     def test_speaking_sets_is_speaking(self, mic):
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
         loud = _make_chunk(-20)
         drive(mic, loud, 1)
         assert mic._is_speaking is True
 
     def test_silence_after_speech_flushes_if_long_enough(self, mic):
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
-
         loud = _make_chunk(-20)
         silent = _make_chunk(-70)
         from core.mic_analyzer import SILENCE_CHUNKS_TO_FLUSH
@@ -102,9 +84,6 @@ class TestNormalVADFlow:
         assert mic._vad_buffer == []
 
     def test_short_noise_spike_below_min_chunks_not_flushed(self, mic):
-        async def fake_stt(_): pass
-        mic.set_stt_callback(fake_stt)
-
         loud = _make_chunk(-20)
         silent = _make_chunk(-70)
         from core.mic_analyzer import SILENCE_CHUNKS_TO_FLUSH
@@ -112,6 +91,5 @@ class TestNormalVADFlow:
         drive(mic, loud, MIN_SPEECH_CHUNKS - 1)
         drive(mic, silent, SILENCE_CHUNKS_TO_FLUSH)
 
-        # Buffer should be cleared but stt_callback should NOT have been scheduled
         assert mic._is_speaking is False
         assert mic._vad_buffer == []

--- a/tests/test_mic_analyzer.py
+++ b/tests/test_mic_analyzer.py
@@ -1,0 +1,117 @@
+"""Unit tests for MicAnalyzer VAD state machine."""
+import asyncio
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch
+
+from core.mic_analyzer import MicAnalyzer, MAX_SPEECH_CHUNKS, MIN_SPEECH_CHUNKS, CHUNK_FRAMES, SAMPLE_RATE
+
+
+def _make_chunk(db: float) -> np.ndarray:
+    """Return a mono int16 chunk with the given RMS level (dBFS)."""
+    rms = 10.0 ** (db / 20.0)
+    amplitude = int(min(rms * 32767, 32767))
+    return np.full(CHUNK_FRAMES, amplitude, dtype=np.int16).reshape(-1, 1)
+
+
+@pytest.fixture
+def mic():
+    loop = asyncio.new_event_loop()
+    m = MicAnalyzer(loop)
+    m._threshold_db = -35.0
+    yield m
+    loop.close()
+
+
+def drive(mic: MicAnalyzer, chunk: np.ndarray, count: int) -> None:
+    """Feed `count` identical chunks into the audio callback."""
+    with patch("core.mic_analyzer.asyncio.run_coroutine_threadsafe") as mock_rct:
+        mock_rct.return_value = MagicMock()
+        for _ in range(count):
+            mic._audio_callback(chunk, CHUNK_FRAMES, None, None)
+
+
+class TestEarlyFlush:
+    def test_early_flush_resets_is_speaking(self, mic):
+        """_is_speaking must be False after MAX_SPEECH_CHUNKS triggers an early flush."""
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+
+        loud = _make_chunk(-20)
+        drive(mic, loud, MAX_SPEECH_CHUNKS)
+
+        assert mic._is_speaking is False, "_is_speaking must be reset after early flush"
+
+    def test_early_flush_clears_vad_buffer(self, mic):
+        """_vad_buffer must be empty after early flush."""
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+
+        loud = _make_chunk(-20)
+        drive(mic, loud, MAX_SPEECH_CHUNKS)
+
+        assert mic._vad_buffer == []
+
+    def test_early_flush_resets_speech_chunk_count(self, mic):
+        """_speech_chunk_count must be zero after early flush."""
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+
+        loud = _make_chunk(-20)
+        drive(mic, loud, MAX_SPEECH_CHUNKS)
+
+        assert mic._speech_chunk_count == 0
+
+    def test_next_utterance_not_discarded_after_early_flush(self, mic):
+        """Silence after an early flush must not trigger a spurious MIN_SPEECH_CHUNKS rejection."""
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+
+        loud = _make_chunk(-20)
+        silent = _make_chunk(-70)
+
+        # Early flush
+        drive(mic, loud, MAX_SPEECH_CHUNKS)
+        # One silent chunk — should NOT immediately commit a 0-speech-chunk utterance
+        drive(mic, silent, 1)
+
+        # After the single silence, is_speaking should still be False (no new speech)
+        assert mic._is_speaking is False
+
+
+class TestNormalVADFlow:
+    def test_speaking_sets_is_speaking(self, mic):
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+        loud = _make_chunk(-20)
+        drive(mic, loud, 1)
+        assert mic._is_speaking is True
+
+    def test_silence_after_speech_flushes_if_long_enough(self, mic):
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+
+        loud = _make_chunk(-20)
+        silent = _make_chunk(-70)
+        from core.mic_analyzer import SILENCE_CHUNKS_TO_FLUSH
+
+        drive(mic, loud, MIN_SPEECH_CHUNKS + 1)
+        drive(mic, silent, SILENCE_CHUNKS_TO_FLUSH)
+
+        assert mic._is_speaking is False
+        assert mic._vad_buffer == []
+
+    def test_short_noise_spike_below_min_chunks_not_flushed(self, mic):
+        async def fake_stt(_): pass
+        mic.set_stt_callback(fake_stt)
+
+        loud = _make_chunk(-20)
+        silent = _make_chunk(-70)
+        from core.mic_analyzer import SILENCE_CHUNKS_TO_FLUSH
+
+        drive(mic, loud, MIN_SPEECH_CHUNKS - 1)
+        drive(mic, silent, SILENCE_CHUNKS_TO_FLUSH)
+
+        # Buffer should be cleared but stt_callback should NOT have been scheduled
+        assert mic._is_speaking is False
+        assert mic._vad_buffer == []

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,8 @@
 import pytest
 import os
+import re
+import yaml
+from pathlib import Path
 from unittest.mock import MagicMock, patch, AsyncMock
 from fastapi.testclient import TestClient
 
@@ -28,11 +31,14 @@ def test_health_check_endpoint(client):
         assert response.json() == {"status": "ok", "tts_engine": True}
 
 def test_reload_config_endpoint(client):
+    import json as _json
     # Mock nested objects
     parcera_server.config = MagicMock()
     parcera_server.current_stt_provider = "faster_whisper"
     parcera_server.current_tts_provider = "aivisspeech"
     parcera_server.current_llm_provider = "gemini"
+    # Pre-set hash so LLM is not detected as changed (no "llm" key in new_settings)
+    parcera_server.current_llm_hash = _json.dumps({}, sort_keys=True)
     parcera_server.apply_runtime_config = MagicMock()
     parcera_server._sync_to_server = MagicMock()
 
@@ -80,6 +86,26 @@ def test_reload_config_restart_required(client):
     assert response.status_code == 200
     data = response.json()
     assert data["restart_required"] == True
+
+def test_merge_request_threshold_constructor_default_matches_yaml():
+    """Regression: hardcoded fallback in ParceraServer.__init__ must equal the YAML default."""
+    yaml_path = Path(__file__).parent.parent / "configs" / "settings.default.yaml"
+    with yaml_path.open() as f:
+        defaults = yaml.safe_load(f)
+    yaml_default = float(defaults["merge_request_threshold"])
+
+    source = (Path(__file__).parent.parent / "src" / "run_server.py").read_text()
+    m = re.search(
+        r'merge_request_threshold=self\.config\.get\("merge_request_threshold",\s*([\d.]+)\)',
+        source,
+    )
+    assert m is not None, "Could not find merge_request_threshold default in constructor"
+    code_default = float(m.group(1))
+    assert code_default == yaml_default, (
+        f"Constructor fallback {code_default} != YAML default {yaml_default}. "
+        "Both should be 0.6."
+    )
+
 
 def test_get_tts_speakers_endpoint(client):
     # Mock config settings

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "parcera",
   "productName": "Parcera",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "parcera",
   "productName": "Parcera",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -25,11 +25,16 @@
       border-radius: 2px;
       pointer-events: none;
     }
+    #avatar.chromakey { filter: url(#chromakey-filter); }
   </style>
 </head>
 <body>
   <img id="avatar" alt="">
   <div id="dbg" hidden></div>
+  <!-- SVG chroma key filter — mirrors ChromaKeyFilter.tsx (feColorMatrix alpha extraction) -->
+  <svg width="0" height="0" style="position:absolute;pointer-events:none">
+    <defs><filter id="chromakey-filter"></filter></defs>
+  </svg>
 <script>
 (function () {
   // ── Port resolution ──────────────────────────────────────────────────────────
@@ -175,6 +180,25 @@
 
     var showDebug = !(s.avatars && s.avatars.show_debug === false);
     dbg.hidden = !showDebug;
+
+    // Chroma key: SVG feColorMatrix filter, same logic as ChromaKeyFilter.tsx.
+    var avatarCfg = s.avatars && s.avatars[avatarType];
+    var chromaEnabled = !!(avatarCfg && avatarCfg.chroma_key_enabled);
+    var chromaColor   = (avatarCfg && avatarCfg.chroma_key_color) || 'green';
+    var filterEl = document.getElementById('chromakey-filter');
+    if (chromaEnabled) {
+      var m = chromaColor === 'green'
+        ? '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  3.0 -6.0 3.0 1.0 0.5'
+        : '1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  3.0 3.0 -6.0 1.0 0.5';
+      filterEl.setAttribute('color-interpolation-filters', 'sRGB');
+      filterEl.innerHTML = '<feColorMatrix type="matrix" values="' + m + '"/>'
+        + '<feComponentTransfer><feFuncA type="table" tableValues="0 1"/></feComponentTransfer>';
+      img.classList.add('chromakey');
+    } else {
+      filterEl.removeAttribute('color-interpolation-filters');
+      filterEl.innerHTML = '<feColorMatrix type="matrix" values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>';
+      img.classList.remove('chromakey');
+    }
 
     img.removeAttribute('style');
     img.src = assetsDir + '/base.png?v=' + cacheKey;

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    *, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; background: transparent; overflow: hidden; }
+    #avatar {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      object-position: top left;
+      transform-origin: top center;
+      pointer-events: none;
+      display: block;
+    }
+    #dbg {
+      position: fixed;
+      bottom: 4px;
+      left: 4px;
+      background: rgba(0,0,0,.75);
+      color: #fff;
+      font: 11px/1.4 monospace;
+      padding: 2px 4px;
+      border-radius: 2px;
+      pointer-events: none;
+    }
+  </style>
+</head>
+<body>
+  <img id="avatar" alt="">
+  <div id="dbg" hidden></div>
+<script>
+(function () {
+  // ── Config ──────────────────────────────────────────────────────────────────
+  var p = new URLSearchParams(location.search);
+  var avatarType = p.get('type') || 'user';
+  var frontendPort = parseInt(location.port, 10) || 8677;
+  // Dev server runs on 5173; map to hard-coded Python port in that case.
+  var pythonPort = (frontendPort >= 5000 && frontendPort < 6000) ? 8676 : (frontendPort - 1);
+  var pythonHttp = 'http://127.0.0.1:' + pythonPort;
+  var wsUrl     = 'ws://127.0.0.1:' + pythonPort + '/ws';
+  // Default assets come from the Tauri static server (same origin as this page).
+  var assetsDir = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
+
+  // ── Constants ────────────────────────────────────────────────────────────────
+  var TALK_THRESHOLD       = 0.05;
+  var BLINK_CLOSE_MS       = 150;
+  var DEFAULT_BLINK_MIN    = 5000;
+  var DEFAULT_BLINK_MAX    = 15000;
+  var DEFAULT_MOUTH_HOLD   = 120;
+  var DB_FLOOR             = -55;
+  var DB_CEIL              = -5;
+  var METER_SIZE           = 15;
+  // Vowels that map to a non-standard filename (nasal ん → closed mouth).
+  var VOWEL_OVERRIDE       = { n: 'base.png' };
+
+  // ── Mutable state ────────────────────────────────────────────────────────────
+  var settings        = {};
+  var extLipsync      = null;   // {env, rawAmplitude, vowel} | null
+  var currentMouth    = 'base.png';
+  var mouthHoldTimer  = 0;
+  var isBlinking      = false;
+  var blinkTimer      = Date.now() + 2000;
+  var breatheTime     = Math.random() * 100;
+  var lastFrameTime   = performance.now();
+
+  // ── DOM ──────────────────────────────────────────────────────────────────────
+  var img = document.getElementById('avatar');
+  var dbg = document.getElementById('dbg');
+
+  // ── Settings ─────────────────────────────────────────────────────────────────
+  function applySettings(s) {
+    settings = s;
+
+    var avatarCfg = s.avatars && s.avatars[avatarType];
+    if (typeof avatarCfg === 'object' && avatarCfg && avatarCfg.assets_dir) {
+      // Custom avatar path — use file:// (OBS CEF allows cross-origin file loads).
+      assetsDir = 'file://' + avatarCfg.assets_dir;
+    } else {
+      assetsDir = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
+    }
+
+    var showDebug = !(s.avatars && s.avatars.show_debug === false);
+    dbg.hidden = !showDebug;
+
+    // Reset image to base so the correct assetsDir takes effect immediately.
+    if (img.src !== assetsDir + '/base.png') {
+      img.removeAttribute('style');
+      img.src = assetsDir + '/base.png';
+    }
+  }
+
+  function fetchSettings() {
+    fetch(pythonHttp + '/config/settings', { cache: 'no-store' })
+      .then(function (r) { return r.json(); })
+      .then(applySettings)
+      .catch(function () { setTimeout(fetchSettings, 3000); });
+  }
+
+  // ── Image error recovery ─────────────────────────────────────────────────────
+  img.addEventListener('error', function () {
+    var src = img.src;
+    if (src.endsWith('/e.png')) {
+      img.src = src.replace('/e.png', '/a.png');
+    } else if (src.endsWith('/o.png')) {
+      img.src = src.replace('/o.png', '/u.png');
+    } else if (!src.endsWith('/base.png')) {
+      // Any other missing vowel image → reset to base and break flicker loop.
+      currentMouth   = 'base.png';
+      mouthHoldTimer = 0;
+      img.src = assetsDir + '/base.png';
+    } else {
+      img.style.opacity = '0.5';
+    }
+  });
+
+  // ── WebSocket ────────────────────────────────────────────────────────────────
+  var ws;
+  var wsSessionId = 'lipsync-' + Math.random().toString(36).slice(2, 9);
+
+  function connectWS() {
+    ws = new WebSocket(wsUrl);
+
+    ws.onopen = function () {
+      ws.send(JSON.stringify({ type: 'start', session_id: wsSessionId }));
+      // Refresh settings on every (re)connect so a Parcera restart picks up
+      // any config changes without needing a manual page reload.
+      fetchSettings();
+    };
+
+    ws.onmessage = function (e) {
+      try {
+        var d = JSON.parse(e.data);
+        if (d.type === 'user_lipsync') {
+          var vowel    = d.vowel || null;
+          var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
+          var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
+          extLipsync   = {
+            env:         speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
+            rawAmplitude: amp,
+            vowel:        vowel
+          };
+        }
+      } catch (_) {}
+    };
+
+    ws.onclose = function () {
+      extLipsync = null;
+      setTimeout(connectWS, 3000);
+    };
+    ws.onerror = function () {};
+  }
+
+  // ── Animation loop ───────────────────────────────────────────────────────────
+  function frame() {
+    var now = performance.now();
+    var dt  = (now - lastFrameTime) / 1000;
+    lastFrameTime = now;
+
+    // --- Breathing ---
+    var bDur   = (settings.avatars && settings.avatars.breathe_duration)  || 5000;
+    var bScale = (settings.avatars && settings.avatars.breathe_scale)     || 1.005;
+    var bAmp   = (settings.avatars && settings.avatars.breathe_amplitude) || 2;
+    breatheTime += dt * (2 * Math.PI) / (bDur / 1000);
+    var wave   = Math.sin(breatheTime) + 0.5 * Math.sin(breatheTime * 1.618);
+    var norm   = wave / 1.5;
+    var offsetY = (norm + 1) * 0.5 * bAmp;
+    var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
+    img.style.transform = 'translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
+
+    // --- Lipsync state ---
+    var env    = extLipsync ? extLipsync.env         : 0;
+    var rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;
+    var vowel  = (extLipsync && extLipsync.env > TALK_THRESHOLD)
+      ? (extLipsync.vowel || '-') : '-';
+
+    // --- Debug overlay ---
+    if (!dbg.hidden) {
+      var db     = 20 * Math.log10(Math.max(rmsRaw, 0.00001));
+      var span   = DB_CEIL - DB_FLOOR;
+      var lvl    = Math.max(0, Math.min(1, (db - DB_FLOOR) / span));
+      var on     = Math.floor(lvl * METER_SIZE);
+      var tDbV   = (settings.vad && settings.vad.volume_db_threshold) || -20;
+      var tPos   = Math.floor(Math.max(0, Math.min(1, (tDbV - DB_FLOOR) / span)) * METER_SIZE);
+      var meter  = '';
+      for (var i = 0; i < METER_SIZE; i++) {
+        if (i === tPos) {
+          meter += '<span style="color:#ff0;font-weight:bold">|</span>';
+        } else if (i < on) {
+          var col = db >= DB_CEIL ? '#f44' : env > TALK_THRESHOLD ? '#4f4' : '#999';
+          meter += '<span style="color:' + col + '">█</span>';
+        } else {
+          meter += '<span style="color:#444">░</span>';
+        }
+      }
+      var envPct = (env * 100).toFixed(0);
+      dbg.innerHTML = '[' + meter + '] ' + db.toFixed(1) + 'dB | Env:' + envPct + '% | Vowel:' + vowel;
+    }
+
+    // --- Blink ---
+    var nowMs   = Date.now();
+    var minBl   = (settings.avatars && settings.avatars.blink_interval_min) || DEFAULT_BLINK_MIN;
+    var maxBl   = (settings.avatars && settings.avatars.blink_interval_max) || DEFAULT_BLINK_MAX;
+    var holdMs  = (settings.avatars && settings.avatars.mouth_hold_time)    || DEFAULT_MOUTH_HOLD;
+    var target  = 'base.png';
+
+    if (nowMs > blinkTimer) {
+      if (!isBlinking) {
+        isBlinking = true;
+        blinkTimer = nowMs + BLINK_CLOSE_MS;
+      } else {
+        isBlinking = false;
+        blinkTimer = nowMs + minBl + Math.random() * (maxBl - minBl);
+      }
+    }
+
+    if (isBlinking) {
+      target = 'closed.png';
+    } else {
+      if (nowMs > mouthHoldTimer) {
+        var next = 'base.png';
+        if (env > TALK_THRESHOLD && vowel && vowel !== '?' && vowel !== '-') {
+          next = VOWEL_OVERRIDE[vowel] || (vowel + '.png');
+        }
+        if (next !== currentMouth) {
+          currentMouth   = next;
+          mouthHoldTimer = nowMs + holdMs;
+        }
+      }
+      target = currentMouth;
+    }
+
+    // --- Apply image ---
+    var newSrc = assetsDir + '/' + target;
+    var absNew = new URL(newSrc, location.href).href;
+    if (img.src !== absNew) {
+      img.src = newSrc;
+      // Per-change onerror resets internal state to prevent the
+      // visual-loop ↔ error-handler flicker cycle for missing sprites.
+      img.onerror = function () {
+        if (target !== 'base.png' && target !== 'closed.png') {
+          currentMouth   = 'base.png';
+          mouthHoldTimer = 0;
+        }
+        img.src      = assetsDir + '/base.png';
+        img.onerror  = null;
+      };
+    }
+
+    // Use setTimeout when hidden so animation keeps running at ~30 fps
+    // even when the OBS source is not in the active scene.
+    if (document.hidden) {
+      setTimeout(frame, 33);
+    } else {
+      requestAnimationFrame(frame);
+    }
+  }
+
+  // ── Boot ─────────────────────────────────────────────────────────────────────
+  fetchSettings();
+  connectWS();
+  requestAnimationFrame(frame);
+})();
+</script>
+</body>
+</html>

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -58,8 +58,8 @@
   var avatarType  = p.get('type') || 'user';
   var pythonHttp  = 'http://127.0.0.1:' + pythonPort;
   var wsUrl       = 'ws://127.0.0.1:' + pythonPort + '/ws';
-  // Images are always proxied through Python so obs.html (an http:// page)
-  // never needs file:// URLs (blocked by Chromium's mixed-content policy).
+  // Images are always served via the Python proxy so obs.html (an http:// page)
+  // can load them without hitting the browser's file:// mixed-content block.
   var assetsDir   = pythonHttp + '/config/obs-asset/' + avatarType;
 
   // ── Constants ────────────────────────────────────────────────────────────────
@@ -237,8 +237,8 @@
     ws = new WebSocket(wsUrl);
     ws.onopen = function () {
       ws.send(JSON.stringify({ type: 'start', session_id: wsSessionId }));
-      // Refresh settings on every (re)connect so a Parcera restart picks up
-      // any config changes without needing a manual page reload.
+      // Re-fetch settings on every (re)connect so Parcera restarts pick up
+      // config changes without a manual OBS refresh.
       fetchSettings();
     };
     ws.onmessage = function (e) {
@@ -258,7 +258,7 @@
             var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
             var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
             extLipsync   = {
-              env:         speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
+              env:          speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
               rawAmplitude: amp,
               vowel:        vowel
             };
@@ -266,12 +266,12 @@
         }
       } catch (_) {}
     };
-    ws.onclose = function () {
+    ws.onclose  = function () {
       extLipsync = null;
       flushAIQueue();
       setTimeout(connectWS, 3000);
     };
-    ws.onerror = function () {};
+    ws.onerror  = function () {};
   }
 
   // ── Animation loop ───────────────────────────────────────────────────────────
@@ -285,8 +285,8 @@
     var bScale = (settings.avatars && settings.avatars.breathe_scale)     || 1.005;
     var bAmp   = (settings.avatars && settings.avatars.breathe_amplitude) || 2;
     breatheTime += dt * (2 * Math.PI) / (bDur / 1000);
-    var wave   = Math.sin(breatheTime) + 0.5 * Math.sin(breatheTime * 1.618);
-    var norm   = wave / 1.5;
+    var wave    = Math.sin(breatheTime) + 0.5 * Math.sin(breatheTime * 1.618);
+    var norm    = wave / 1.5;
     var offsetY = (norm + 1) * 0.5 * bAmp;
     var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
     img.style.transform = 'scaleX(' + flipX + ') translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
@@ -309,13 +309,12 @@
 
     // Debug overlay
     if (!dbg.hidden) {
-      var db     = 20 * Math.log10(Math.max(rmsRaw, 0.00001));
-      var span   = DB_CEIL - DB_FLOOR;
-      var lvl    = Math.max(0, Math.min(1, (db - DB_FLOOR) / span));
-      var on     = Math.floor(lvl * METER_SIZE);
-      var tDbV   = (settings.vad && settings.vad.volume_db_threshold) || -20;
-      var tPos   = Math.floor(Math.max(0, Math.min(1, (tDbV - DB_FLOOR) / span)) * METER_SIZE);
-      var meter  = '';
+      var db   = 20 * Math.log10(Math.max(rmsRaw, 0.00001));
+      var span = DB_CEIL - DB_FLOOR;
+      var on   = Math.floor(Math.max(0, Math.min(1, (db - DB_FLOOR) / span)) * METER_SIZE);
+      var tDb  = (settings.vad && settings.vad.volume_db_threshold) || -20;
+      var tPos = Math.floor(Math.max(0, Math.min(1, (tDb - DB_FLOOR) / span)) * METER_SIZE);
+      var meter = '';
       for (var i = 0; i < METER_SIZE; i++) {
         if (i === tPos) {
           meter += '<span style="color:#ff0;font-weight:bold">|</span>';
@@ -326,16 +325,15 @@
           meter += '<span style="color:#444">░</span>';
         }
       }
-      var envPct = (env * 100).toFixed(0);
-      dbg.innerHTML = '[' + meter + '] ' + db.toFixed(1) + 'dB | Env:' + envPct + '% | Vowel:' + vowel;
+      dbg.innerHTML = '[' + meter + '] ' + db.toFixed(1) + 'dB | Env:' + (env * 100).toFixed(0) + '% | Vowel:' + vowel;
     }
 
     // Blink
-    var nowMs   = Date.now();
-    var minBl   = (settings.avatars && settings.avatars.blink_interval_min) || DEFAULT_BLINK_MIN;
-    var maxBl   = (settings.avatars && settings.avatars.blink_interval_max) || DEFAULT_BLINK_MAX;
-    var holdMs  = (settings.avatars && settings.avatars.mouth_hold_time)    || DEFAULT_MOUTH_HOLD;
-    var target  = 'base.png';
+    var nowMs  = Date.now();
+    var minBl  = (settings.avatars && settings.avatars.blink_interval_min) || DEFAULT_BLINK_MIN;
+    var maxBl  = (settings.avatars && settings.avatars.blink_interval_max) || DEFAULT_BLINK_MAX;
+    var holdMs = (settings.avatars && settings.avatars.mouth_hold_time)    || DEFAULT_MOUTH_HOLD;
+    var target = 'base.png';
 
     if (nowMs > blinkTimer) {
       if (!isBlinking) {
@@ -373,18 +371,12 @@
           currentMouth   = 'base.png';
           mouthHoldTimer = 0;
         }
-        img.src      = assetsDir + '/base.png?v=' + cacheKey;
-        img.onerror  = null;
+        img.src     = assetsDir + '/base.png?v=' + cacheKey;
+        img.onerror = null;
       };
     }
 
-    // Use setTimeout when hidden so animation keeps running at ~30 fps
-    // even when the OBS source is not in the active scene.
-    if (document.hidden) {
-      setTimeout(frame, 33);
-    } else {
-      requestAnimationFrame(frame);
-    }
+    if (document.hidden) { setTimeout(frame, 33); } else { requestAnimationFrame(frame); }
   }
 
   // ── Boot ─────────────────────────────────────────────────────────────────────

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -77,6 +77,7 @@
   // ── Mutable state ────────────────────────────────────────────────────────────
   var settings       = {};
   var cacheKey       = 0;     // bumped on every applySettings; busts asset cache
+  var flipX          = 1;     // 1 = normal, -1 = horizontal flip
   var extLipsync     = null;   // user-avatar only: {env, rawAmplitude, vowel}
   var currentMouth   = 'base.png';
   var mouthHoldTimer = 0;
@@ -200,6 +201,8 @@
       img.classList.remove('chromakey');
     }
 
+    flipX = (avatarCfg && avatarCfg.flip_horizontal) ? -1 : 1;
+
     img.removeAttribute('style');
     img.src = assetsDir + '/base.png?v=' + cacheKey;
   }
@@ -288,7 +291,7 @@
     var norm   = wave / 1.5;
     var offsetY = (norm + 1) * 0.5 * bAmp;
     var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
-    img.style.transform = 'translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
+    img.style.transform = 'scaleX(' + flipX + ') translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
 
     // Lipsync state — source differs by avatar type
     var env, rmsRaw, vowel;

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -71,6 +71,7 @@
 
   // ── Mutable state ────────────────────────────────────────────────────────────
   var settings       = {};
+  var cacheKey       = 0;     // bumped on every applySettings; busts asset cache
   var extLipsync     = null;   // user-avatar only: {env, rawAmplitude, vowel}
   var currentMouth   = 'base.png';
   var mouthHoldTimer = 0;
@@ -168,15 +169,23 @@
   // ── Settings ─────────────────────────────────────────────────────────────────
   function applySettings(s) {
     settings = s;
-    // assetsDir is fixed to the Python proxy — no file:// needed.
+    // Bump cacheKey so every asset URL gets a fresh ?v= param.
+    // This forces the browser to re-fetch sprites when assets_dir changes.
+    cacheKey = Date.now();
+
     var showDebug = !(s.avatars && s.avatars.show_debug === false);
     dbg.hidden = !showDebug;
 
-    // Reset image to base so the correct assetsDir takes effect immediately.
-    if (img.src !== assetsDir + '/base.png') {
-      img.removeAttribute('style');
-      img.src = assetsDir + '/base.png';
+    // Chroma key background (mirrors Tauri avatar window behaviour).
+    var avatarCfg = s.avatars && s.avatars[avatarType];
+    if (avatarCfg && avatarCfg.chroma_key_enabled) {
+      document.body.style.background = avatarCfg.chroma_key_color || 'green';
+    } else {
+      document.body.style.background = 'transparent';
     }
+
+    img.removeAttribute('style');
+    img.src = assetsDir + '/base.png?v=' + cacheKey;
   }
 
   function fetchSettings() {
@@ -337,8 +346,8 @@
       target = currentMouth;
     }
 
-    // Apply image
-    var newSrc = assetsDir + '/' + target;
+    // Apply image (include cacheKey so asset changes propagate after config reload)
+    var newSrc = assetsDir + '/' + target + '?v=' + cacheKey;
     var absNew = new URL(newSrc, location.href).href;
     if (img.src !== absNew) {
       img.src = newSrc;
@@ -347,7 +356,7 @@
           currentMouth   = 'base.png';
           mouthHoldTimer = 0;
         }
-        img.src      = assetsDir + '/base.png';
+        img.src      = assetsDir + '/base.png?v=' + cacheKey;
         img.onerror  = null;
       };
     }

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -39,20 +39,19 @@
 (function () {
   // ── Port resolution ──────────────────────────────────────────────────────────
   // This page may be served from:
-  //   port 8676  — Python AI server (canonical OBS URL)
-  //   port 8677  — Tauri localhost plugin (fallback / dev workaround)
+  //   port 8676  — Python AI server (canonical OBS URL via file:// or http://)
+  //   port 8677  — Tauri localhost plugin (fallback)
   //   port 5173  — Vite dev server
-  // In all cases pythonPort = 8676 and frontendPort = 8677 (for Tauri assets).
-  var PYTHON_PORT   = 8676;
-  var FRONTEND_PORT = 8677;
+  // In all cases pythonPort resolves to 8676.
+  var PYTHON_PORT = 8676;
   var locPort = parseInt(location.port, 10);
-  var pythonPort, frontendPort;
+  var pythonPort;
   if (locPort === PYTHON_PORT || (locPort >= 5000 && locPort < 6000)) {
-    pythonPort   = PYTHON_PORT;
-    frontendPort = FRONTEND_PORT;
+    pythonPort = PYTHON_PORT;
   } else {
-    frontendPort = locPort || FRONTEND_PORT;
-    pythonPort   = frontendPort - 1;
+    // file:// → locPort=NaN → default to PYTHON_PORT+1-1=PYTHON_PORT
+    // Tauri (8677) → 8677-1=8676
+    pythonPort = (locPort || (PYTHON_PORT + 1)) - 1;
   }
 
   var p = new URLSearchParams(location.search);
@@ -179,8 +178,7 @@
     // This forces the browser to re-fetch sprites when assets_dir changes.
     cacheKey = Date.now();
 
-    var showDebug = !(s.avatars && s.avatars.show_debug === false);
-    dbg.hidden = !showDebug;
+    dbg.hidden = !(s.avatars && s.avatars.show_debug !== false);
 
     // Chroma key: SVG feColorMatrix filter, same logic as ChromaKeyFilter.tsx.
     var avatarCfg = s.avatars && s.avatars[avatarType];

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -40,8 +40,9 @@
   var pythonPort = (frontendPort >= 5000 && frontendPort < 6000) ? 8676 : (frontendPort - 1);
   var pythonHttp = 'http://127.0.0.1:' + pythonPort;
   var wsUrl     = 'ws://127.0.0.1:' + pythonPort + '/ws';
-  // Default assets come from the Tauri static server (same origin as this page).
-  var assetsDir = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
+  // Images are always proxied through Python so obs.html (an http:// page)
+  // never needs file:// URLs (blocked by Chromium's mixed-content policy).
+  var assetsDir = pythonHttp + '/config/obs-asset/' + avatarType;
 
   // ── Constants ────────────────────────────────────────────────────────────────
   var TALK_THRESHOLD       = 0.05;
@@ -73,14 +74,7 @@
   function applySettings(s) {
     settings = s;
 
-    var avatarCfg = s.avatars && s.avatars[avatarType];
-    if (typeof avatarCfg === 'object' && avatarCfg && avatarCfg.assets_dir) {
-      // Custom avatar path — use file:// (OBS CEF allows cross-origin file loads).
-      assetsDir = 'file://' + avatarCfg.assets_dir;
-    } else {
-      assetsDir = 'http://127.0.0.1:' + frontendPort + '/assets/' + avatarType;
-    }
-
+    // assetsDir is fixed to the Python proxy — no file:// needed.
     var showDebug = !(s.avatars && s.avatars.show_debug === false);
     dbg.hidden = !showDebug;
 

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -83,9 +83,17 @@
   var dbg = document.getElementById('dbg');
 
   // ── AI audio playback (type=ai only) ─────────────────────────────────────────
+  // Mirror of audio.ts constants for spectral-centroid vowel detection.
+  var AI_FFT_SIZE             = 512;
+  var AI_SMOOTHING            = 0.2;
+  var AI_LOW_FREQ_CUTOFF      = 200;   // Hz — ignore rumble below this
+  var AI_SILENCE_AMP_FLOOR    = 0.001;
+  var AI_VOWEL_HZ             = { u: 600, o: 1500, a: 3000, e: 5000 };
+
   var audioCtx     = null;
   var aiAnalyser   = null;
-  var aiTimeBuf    = null;
+  var aiTimeBuf    = null;   // Float32Array(fftSize) for RMS
+  var aiFreqBuf    = null;   // Float32Array(frequencyBinCount) for vowel
   var audioQueue   = [];
   var isAIPlaying  = false;
 
@@ -93,21 +101,41 @@
     if (audioCtx) return;
     audioCtx   = new AudioContext();
     aiAnalyser = audioCtx.createAnalyser();
-    aiAnalyser.fftSize = 256;
-    aiTimeBuf  = new Uint8Array(aiAnalyser.frequencyBinCount);
+    aiAnalyser.fftSize                = AI_FFT_SIZE;
+    aiAnalyser.smoothingTimeConstant  = AI_SMOOTHING;
+    aiTimeBuf  = new Float32Array(AI_FFT_SIZE);
+    aiFreqBuf  = new Float32Array(aiAnalyser.frequencyBinCount);
     aiAnalyser.connect(audioCtx.destination);
     if (audioCtx.state === 'suspended') audioCtx.resume().catch(function () {});
   }
 
   function getAIRms() {
     if (!aiAnalyser || !aiTimeBuf) return 0;
-    aiAnalyser.getByteTimeDomainData(aiTimeBuf);
+    aiAnalyser.getFloatTimeDomainData(aiTimeBuf);
     var sum = 0;
-    for (var i = 0; i < aiTimeBuf.length; i++) {
-      var v = (aiTimeBuf[i] - 128) / 128;
-      sum += v * v;
-    }
+    for (var i = 0; i < aiTimeBuf.length; i++) sum += aiTimeBuf[i] * aiTimeBuf[i];
     return Math.sqrt(sum / aiTimeBuf.length);
+  }
+
+  function getAIVowel() {
+    if (!aiAnalyser || !aiFreqBuf) return null;
+    aiAnalyser.getFloatFrequencyData(aiFreqBuf);
+    var nyquist = audioCtx.sampleRate / 2;
+    var weightedSum = 0, totalAmp = 0;
+    for (var i = 0; i < aiFreqBuf.length; i++) {
+      var hz = (i / aiFreqBuf.length) * nyquist;
+      if (hz <= AI_LOW_FREQ_CUTOFF) continue;
+      var amp = Math.pow(10, aiFreqBuf[i] / 20); // dB → linear
+      weightedSum += amp * hz;
+      totalAmp    += amp;
+    }
+    if (totalAmp < AI_SILENCE_AMP_FLOOR) return null;
+    var centroid = weightedSum / totalAmp;
+    if (centroid < AI_VOWEL_HZ.u) return 'u';
+    if (centroid < AI_VOWEL_HZ.o) return 'o';
+    if (centroid < AI_VOWEL_HZ.a) return 'a';
+    if (centroid < AI_VOWEL_HZ.e) return 'e';
+    return 'i';
   }
 
   function playNextChunk() {
@@ -240,11 +268,12 @@
     // Lipsync state — source differs by avatar type
     var env, rmsRaw, vowel;
     if (avatarType === 'ai') {
-      // Derive lipsync from WebAudio analyser (TTS playback amplitude).
+      // Derive lipsync from WebAudio analyser (TTS playback).
+      // Mirrors audio.ts: spectral-centroid vowel detection on the live PCM stream.
       rmsRaw = getAIRms();
       env    = rmsRaw;
-      // Simple open/close: no per-vowel detection for synthetic TTS audio.
-      vowel  = env > TALK_THRESHOLD ? 'a' : '-';
+      var aiVowel = getAIVowel();
+      vowel  = (env > TALK_THRESHOLD && aiVowel) ? aiVowel : '-';
     } else {
       env    = extLipsync ? extLipsync.env          : 0;
       rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -176,14 +176,6 @@
     var showDebug = !(s.avatars && s.avatars.show_debug === false);
     dbg.hidden = !showDebug;
 
-    // Chroma key background (mirrors Tauri avatar window behaviour).
-    var avatarCfg = s.avatars && s.avatars[avatarType];
-    if (avatarCfg && avatarCfg.chroma_key_enabled) {
-      document.body.style.background = avatarCfg.chroma_key_color || 'green';
-    } else {
-      document.body.style.background = 'transparent';
-    }
-
     img.removeAttribute('style');
     img.src = assetsDir + '/base.png?v=' + cacheKey;
   }

--- a/ui/public/obs.html
+++ b/ui/public/obs.html
@@ -32,48 +32,114 @@
   <div id="dbg" hidden></div>
 <script>
 (function () {
-  // ── Config ──────────────────────────────────────────────────────────────────
+  // ── Port resolution ──────────────────────────────────────────────────────────
+  // This page may be served from:
+  //   port 8676  — Python AI server (canonical OBS URL)
+  //   port 8677  — Tauri localhost plugin (fallback / dev workaround)
+  //   port 5173  — Vite dev server
+  // In all cases pythonPort = 8676 and frontendPort = 8677 (for Tauri assets).
+  var PYTHON_PORT   = 8676;
+  var FRONTEND_PORT = 8677;
+  var locPort = parseInt(location.port, 10);
+  var pythonPort, frontendPort;
+  if (locPort === PYTHON_PORT || (locPort >= 5000 && locPort < 6000)) {
+    pythonPort   = PYTHON_PORT;
+    frontendPort = FRONTEND_PORT;
+  } else {
+    frontendPort = locPort || FRONTEND_PORT;
+    pythonPort   = frontendPort - 1;
+  }
+
   var p = new URLSearchParams(location.search);
-  var avatarType = p.get('type') || 'user';
-  var frontendPort = parseInt(location.port, 10) || 8677;
-  // Dev server runs on 5173; map to hard-coded Python port in that case.
-  var pythonPort = (frontendPort >= 5000 && frontendPort < 6000) ? 8676 : (frontendPort - 1);
-  var pythonHttp = 'http://127.0.0.1:' + pythonPort;
-  var wsUrl     = 'ws://127.0.0.1:' + pythonPort + '/ws';
+  var avatarType  = p.get('type') || 'user';
+  var pythonHttp  = 'http://127.0.0.1:' + pythonPort;
+  var wsUrl       = 'ws://127.0.0.1:' + pythonPort + '/ws';
   // Images are always proxied through Python so obs.html (an http:// page)
   // never needs file:// URLs (blocked by Chromium's mixed-content policy).
-  var assetsDir = pythonHttp + '/config/obs-asset/' + avatarType;
+  var assetsDir   = pythonHttp + '/config/obs-asset/' + avatarType;
 
   // ── Constants ────────────────────────────────────────────────────────────────
-  var TALK_THRESHOLD       = 0.05;
-  var BLINK_CLOSE_MS       = 150;
-  var DEFAULT_BLINK_MIN    = 5000;
-  var DEFAULT_BLINK_MAX    = 15000;
-  var DEFAULT_MOUTH_HOLD   = 120;
-  var DB_FLOOR             = -55;
-  var DB_CEIL              = -5;
-  var METER_SIZE           = 15;
-  // Vowels that map to a non-standard filename (nasal ん → closed mouth).
-  var VOWEL_OVERRIDE       = { n: 'base.png' };
+  var TALK_THRESHOLD     = 0.05;
+  var BLINK_CLOSE_MS     = 150;
+  var DEFAULT_BLINK_MIN  = 5000;
+  var DEFAULT_BLINK_MAX  = 15000;
+  var DEFAULT_MOUTH_HOLD = 120;
+  var DB_FLOOR           = -55;
+  var DB_CEIL            = -5;
+  var METER_SIZE         = 15;
+  var VOWEL_OVERRIDE     = { n: 'base.png' };
 
   // ── Mutable state ────────────────────────────────────────────────────────────
-  var settings        = {};
-  var extLipsync      = null;   // {env, rawAmplitude, vowel} | null
-  var currentMouth    = 'base.png';
-  var mouthHoldTimer  = 0;
-  var isBlinking      = false;
-  var blinkTimer      = Date.now() + 2000;
-  var breatheTime     = Math.random() * 100;
-  var lastFrameTime   = performance.now();
+  var settings       = {};
+  var extLipsync     = null;   // user-avatar only: {env, rawAmplitude, vowel}
+  var currentMouth   = 'base.png';
+  var mouthHoldTimer = 0;
+  var isBlinking     = false;
+  var blinkTimer     = Date.now() + 2000;
+  var breatheTime    = Math.random() * 100;
+  var lastFrameTime  = performance.now();
 
-  // ── DOM ──────────────────────────────────────────────────────────────────────
   var img = document.getElementById('avatar');
   var dbg = document.getElementById('dbg');
+
+  // ── AI audio playback (type=ai only) ─────────────────────────────────────────
+  var audioCtx     = null;
+  var aiAnalyser   = null;
+  var aiTimeBuf    = null;
+  var audioQueue   = [];
+  var isAIPlaying  = false;
+
+  function initAudioCtx() {
+    if (audioCtx) return;
+    audioCtx   = new AudioContext();
+    aiAnalyser = audioCtx.createAnalyser();
+    aiAnalyser.fftSize = 256;
+    aiTimeBuf  = new Uint8Array(aiAnalyser.frequencyBinCount);
+    aiAnalyser.connect(audioCtx.destination);
+    if (audioCtx.state === 'suspended') audioCtx.resume().catch(function () {});
+  }
+
+  function getAIRms() {
+    if (!aiAnalyser || !aiTimeBuf) return 0;
+    aiAnalyser.getByteTimeDomainData(aiTimeBuf);
+    var sum = 0;
+    for (var i = 0; i < aiTimeBuf.length; i++) {
+      var v = (aiTimeBuf[i] - 128) / 128;
+      sum += v * v;
+    }
+    return Math.sqrt(sum / aiTimeBuf.length);
+  }
+
+  function playNextChunk() {
+    if (audioQueue.length === 0) { isAIPlaying = false; return; }
+    isAIPlaying = true;
+    var b64 = audioQueue.shift();
+    var raw = atob(b64);
+    var buf = new Uint8Array(raw.length);
+    for (var i = 0; i < raw.length; i++) buf[i] = raw.charCodeAt(i);
+    audioCtx.decodeAudioData(buf.buffer, function (decoded) {
+      var src = audioCtx.createBufferSource();
+      src.buffer = decoded;
+      src.connect(aiAnalyser);
+      src.onended = playNextChunk;
+      src.start();
+    }, function () { playNextChunk(); });
+  }
+
+  function enqueueAIChunk(b64) {
+    initAudioCtx();
+    audioQueue.push(b64);
+    if (!isAIPlaying) playNextChunk();
+  }
+
+  function flushAIQueue() {
+    audioQueue.length = 0;
+    isAIPlaying = false;
+  }
 
   // ── Settings ─────────────────────────────────────────────────────────────────
   function applySettings(s) {
     settings = s;
-
     // assetsDir is fixed to the Python proxy — no file:// needed.
     var showDebug = !(s.avatars && s.avatars.show_debug === false);
     dbg.hidden = !showDebug;
@@ -100,7 +166,6 @@
     } else if (src.endsWith('/o.png')) {
       img.src = src.replace('/o.png', '/u.png');
     } else if (!src.endsWith('/base.png')) {
-      // Any other missing vowel image → reset to base and break flicker loop.
       currentMouth   = 'base.png';
       mouthHoldTimer = 0;
       img.src = assetsDir + '/base.png';
@@ -111,36 +176,45 @@
 
   // ── WebSocket ────────────────────────────────────────────────────────────────
   var ws;
-  var wsSessionId = 'lipsync-' + Math.random().toString(36).slice(2, 9);
+  var wsSessionId = (avatarType === 'ai' ? 'obs-ai-' : 'obs-user-') +
+                    Math.random().toString(36).slice(2, 9);
 
   function connectWS() {
     ws = new WebSocket(wsUrl);
-
     ws.onopen = function () {
       ws.send(JSON.stringify({ type: 'start', session_id: wsSessionId }));
       // Refresh settings on every (re)connect so a Parcera restart picks up
       // any config changes without needing a manual page reload.
       fetchSettings();
     };
-
     ws.onmessage = function (e) {
       try {
         var d = JSON.parse(e.data);
-        if (d.type === 'user_lipsync') {
-          var vowel    = d.vowel || null;
-          var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
-          var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
-          extLipsync   = {
-            env:         speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
-            rawAmplitude: amp,
-            vowel:        vowel
-          };
+        if (avatarType === 'ai') {
+          // AI avatar: play TTS audio chunks received from the server.
+          if (d.type === 'start' || d.type === 'thinking') {
+            flushAIQueue();
+          } else if (d.type === 'chunk' && d.audio_data) {
+            enqueueAIChunk(d.audio_data);
+          }
+        } else {
+          // User avatar: animate mouth from Python MicAnalyzer lipsync events.
+          if (d.type === 'user_lipsync') {
+            var vowel    = d.vowel || null;
+            var amp      = typeof d.amplitude === 'number' ? d.amplitude : 0;
+            var speaking = typeof d.speaking  === 'boolean' ? d.speaking : false;
+            extLipsync   = {
+              env:         speaking ? Math.max(amp, TALK_THRESHOLD + 0.01) : amp,
+              rawAmplitude: amp,
+              vowel:        vowel
+            };
+          }
         }
       } catch (_) {}
     };
-
     ws.onclose = function () {
       extLipsync = null;
+      flushAIQueue();
       setTimeout(connectWS, 3000);
     };
     ws.onerror = function () {};
@@ -152,7 +226,7 @@
     var dt  = (now - lastFrameTime) / 1000;
     lastFrameTime = now;
 
-    // --- Breathing ---
+    // Breathing
     var bDur   = (settings.avatars && settings.avatars.breathe_duration)  || 5000;
     var bScale = (settings.avatars && settings.avatars.breathe_scale)     || 1.005;
     var bAmp   = (settings.avatars && settings.avatars.breathe_amplitude) || 2;
@@ -163,13 +237,22 @@
     var scaleV  = 1 + (Math.max(0, norm) * (bScale - 1));
     img.style.transform = 'translateY(' + offsetY + 'px) scale(' + scaleV + ',' + scaleV + ')';
 
-    // --- Lipsync state ---
-    var env    = extLipsync ? extLipsync.env         : 0;
-    var rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;
-    var vowel  = (extLipsync && extLipsync.env > TALK_THRESHOLD)
-      ? (extLipsync.vowel || '-') : '-';
+    // Lipsync state — source differs by avatar type
+    var env, rmsRaw, vowel;
+    if (avatarType === 'ai') {
+      // Derive lipsync from WebAudio analyser (TTS playback amplitude).
+      rmsRaw = getAIRms();
+      env    = rmsRaw;
+      // Simple open/close: no per-vowel detection for synthetic TTS audio.
+      vowel  = env > TALK_THRESHOLD ? 'a' : '-';
+    } else {
+      env    = extLipsync ? extLipsync.env          : 0;
+      rmsRaw = extLipsync ? extLipsync.rawAmplitude : 0;
+      vowel  = (extLipsync && extLipsync.env > TALK_THRESHOLD)
+        ? (extLipsync.vowel || '-') : '-';
+    }
 
-    // --- Debug overlay ---
+    // Debug overlay
     if (!dbg.hidden) {
       var db     = 20 * Math.log10(Math.max(rmsRaw, 0.00001));
       var span   = DB_CEIL - DB_FLOOR;
@@ -192,7 +275,7 @@
       dbg.innerHTML = '[' + meter + '] ' + db.toFixed(1) + 'dB | Env:' + envPct + '% | Vowel:' + vowel;
     }
 
-    // --- Blink ---
+    // Blink
     var nowMs   = Date.now();
     var minBl   = (settings.avatars && settings.avatars.blink_interval_min) || DEFAULT_BLINK_MIN;
     var maxBl   = (settings.avatars && settings.avatars.blink_interval_max) || DEFAULT_BLINK_MAX;
@@ -225,13 +308,11 @@
       target = currentMouth;
     }
 
-    // --- Apply image ---
+    // Apply image
     var newSrc = assetsDir + '/' + target;
     var absNew = new URL(newSrc, location.href).href;
     if (img.src !== absNew) {
       img.src = newSrc;
-      // Per-change onerror resets internal state to prevent the
-      // visual-loop ↔ error-handler flicker cycle for missing sprites.
       img.onerror = function () {
         if (target !== 'base.png' && target !== 'closed.png') {
           currentMouth   = 'base.png';

--- a/ui/renderer/components/Settings.tsx
+++ b/ui/renderer/components/Settings.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { api } from '../lib/api';
+import { listen } from '@tauri-apps/api/event';
 import type { ParceraSettings } from '../../shared/types';
 import { useSettingsState } from '../lib/hooks/useSettingsState';
 import { SidebarLayout } from './layout/SidebarLayout';
@@ -36,11 +37,23 @@ export const Settings: React.FC = () => {
     type: '',
   });
   const [activeSection, setActiveSection] = useState('character');
+  const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     api.getSettings().then(setSettings);
     api.getDefaultSettings().then(setDefaultSettings);
   }, [setSettings]);
+
+  useEffect(() => {
+    const unlisten = listen<boolean>('python-reload-done', (event) => {
+      if (event.payload) {
+        setStatus({ message: '設定を保存しました。一部の変更は再起動後に反映されます。', type: 'success' });
+        if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+        statusTimerRef.current = setTimeout(() => setStatus({ message: '', type: '' }), 8000);
+      }
+    });
+    return () => { unlisten.then((fn) => fn()); };
+  }, []);
 
   const handleRestoreDefaults = useCallback(() => {
     const label = NAV_ITEMS.find((n) => n.id === activeSection)?.label ?? activeSection;
@@ -76,11 +89,10 @@ export const Settings: React.FC = () => {
           }
         }
       }
-      const msg = result.restart_required
-        ? '設定を保存しました。一部の変更は再起動後に反映されます。'
-        : '設定を保存しました！';
-      setStatus({ message: msg, type: 'success' });
-      setTimeout(() => setStatus({ message: '', type: '' }), result.restart_required ? 8000 : 3000);
+      if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+      setStatus({ message: '設定を保存しました！', type: 'success' });
+      // python-reload-done event (via useEffect) will update this if restart is needed
+      statusTimerRef.current = setTimeout(() => setStatus({ message: '', type: '' }), 3000);
     } else {
       setStatus({ message: '保存エラー: ' + result.error, type: 'error' });
     }

--- a/ui/renderer/components/Settings.tsx
+++ b/ui/renderer/components/Settings.tsx
@@ -63,6 +63,16 @@ export const Settings: React.FC = () => {
     setStatus({ message: '保存中...', type: '' });
     const result = await api.saveSettings(settings);
     if (result.success) {
+      // Apply avatar window visibility immediately on save
+      const windows = settings.app?.windows;
+      if (windows) {
+        for (const type of ['user', 'ai'] as const) {
+          const vis = windows[type]?.visible;
+          if (vis !== undefined) {
+            await api.setWindowVisible(type, vis);
+          }
+        }
+      }
       setStatus({ message: '設定を保存しました！', type: 'success' });
       setTimeout(() => setStatus({ message: '', type: '' }), 3000);
     } else {

--- a/ui/renderer/components/Settings.tsx
+++ b/ui/renderer/components/Settings.tsx
@@ -74,18 +74,22 @@ export const Settings: React.FC = () => {
   const handleSave = useCallback(async () => {
     if (!settings) return;
     setStatus({ message: '保存中...', type: '' });
-    const result = await api.saveSettings(settings);
-    if (result.success) {
-      // Apply avatar window visibility and always-on-top on save
+    try {
+      const result = await api.saveSettings(settings);
+      if (!result.success) {
+        setStatus({ message: '保存エラー: ' + result.error, type: 'error' });
+        return;
+      }
+      // Apply avatar window visibility and always-on-top on save (fire-and-forget)
       const windows = settings.app?.windows;
       if (windows) {
         for (const type of ['user', 'ai'] as const) {
           const win = windows[type];
           if (win?.visible !== undefined) {
-            await api.setWindowVisible(type, win.visible);
+            api.setWindowVisible(type, win.visible).catch((e) => console.error('setWindowVisible failed:', e));
           }
           if (win?.alwaysOnTop !== undefined) {
-            await api.setWindowAlwaysOnTop(type, win.alwaysOnTop);
+            api.setWindowAlwaysOnTop(type, win.alwaysOnTop).catch((e) => console.error('setWindowAlwaysOnTop failed:', e));
           }
         }
       }
@@ -93,8 +97,8 @@ export const Settings: React.FC = () => {
       setStatus({ message: '設定を保存しました！', type: 'success' });
       // python-reload-done event (via useEffect) will update this if restart is needed
       statusTimerRef.current = setTimeout(() => setStatus({ message: '', type: '' }), 3000);
-    } else {
-      setStatus({ message: '保存エラー: ' + result.error, type: 'error' });
+    } catch (e) {
+      setStatus({ message: '保存エラー: ' + String(e), type: 'error' });
     }
   }, [settings]);
 

--- a/ui/renderer/components/Settings.tsx
+++ b/ui/renderer/components/Settings.tsx
@@ -52,7 +52,10 @@ export const Settings: React.FC = () => {
         statusTimerRef.current = setTimeout(() => setStatus({ message: '', type: '' }), 8000);
       }
     });
-    return () => { unlisten.then((fn) => fn()); };
+    return () => {
+      unlisten.then((fn) => fn());
+      if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+    };
   }, []);
 
   const handleRestoreDefaults = useCallback(() => {

--- a/ui/renderer/components/Settings.tsx
+++ b/ui/renderer/components/Settings.tsx
@@ -63,13 +63,16 @@ export const Settings: React.FC = () => {
     setStatus({ message: '保存中...', type: '' });
     const result = await api.saveSettings(settings);
     if (result.success) {
-      // Apply avatar window visibility immediately on save
+      // Apply avatar window visibility and always-on-top on save
       const windows = settings.app?.windows;
       if (windows) {
         for (const type of ['user', 'ai'] as const) {
-          const vis = windows[type]?.visible;
-          if (vis !== undefined) {
-            await api.setWindowVisible(type, vis);
+          const win = windows[type];
+          if (win?.visible !== undefined) {
+            await api.setWindowVisible(type, win.visible);
+          }
+          if (win?.alwaysOnTop !== undefined) {
+            await api.setWindowAlwaysOnTop(type, win.alwaysOnTop);
           }
         }
       }

--- a/ui/renderer/components/Settings.tsx
+++ b/ui/renderer/components/Settings.tsx
@@ -76,8 +76,11 @@ export const Settings: React.FC = () => {
           }
         }
       }
-      setStatus({ message: '設定を保存しました！', type: 'success' });
-      setTimeout(() => setStatus({ message: '', type: '' }), 3000);
+      const msg = result.restart_required
+        ? '設定を保存しました。一部の変更は再起動後に反映されます。'
+        : '設定を保存しました！';
+      setStatus({ message: msg, type: 'success' });
+      setTimeout(() => setStatus({ message: '', type: '' }), result.restart_required ? 8000 : 3000);
     } else {
       setStatus({ message: '保存エラー: ' + result.error, type: 'error' });
     }

--- a/ui/renderer/components/sections/AdvancedSection.tsx
+++ b/ui/renderer/components/sections/AdvancedSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { api } from '../../lib/api';
 import { SectionProps } from './types';
 import { FieldRow, PasswordField } from './shared';
@@ -102,11 +102,23 @@ export const AdvancedSection: React.FC<SectionProps> = ({
   const frontendPort = (settings.app as any)?.frontend_port || (port + 1);
   const isWindows = api.platform === 'win32';
 
-  // obs.html is served by the Python server (port=8676) so it does not depend
-  // on the Tauri localhost plugin. OBS loads it once; WebSocket reconnection
-  // handles Parcera restarts without a manual browser-source refresh.
-  const obsAiUrl = `http://localhost:${frontendPort}/?type=ai&obs=1`;
-  const obsUserUrl = `http://localhost:${port}/obs.html?type=user`;
+  // Fetch obs.html's file:// URI from Python so OBS can load the page even
+  // before Parcera's HTTP server is running.  The JS retry loops in obs.html
+  // then connect to WebSocket+settings once Parcera starts.
+  const [obsFileUri, setObsFileUri] = useState<string | null>(null);
+  useEffect(() => {
+    fetch(`http://localhost:${port}/config/obs-html-path`)
+      .then(r => r.json())
+      .then(d => setObsFileUri(d.file_uri as string))
+      .catch(() => {});
+  }, [port]);
+
+  const obsUserUrl = obsFileUri
+    ? `${obsFileUri}?type=user`
+    : `http://localhost:${port}/config/obs.html?type=user`;
+  const obsAiUrl = obsFileUri
+    ? `${obsFileUri}?type=ai`
+    : `http://localhost:${frontendPort}/?type=ai&obs=1`;
 
   return (
     <div className="space-y-6">
@@ -359,7 +371,7 @@ export const AdvancedSection: React.FC<SectionProps> = ({
           <ObsUrlRow label="AI アバター" url={obsAiUrl} />
           <ObsUrlRow label="User アバター" url={obsUserUrl} />
           <p className="text-xs text-muted-foreground">
-            User アバターは独立した静的ページです。Parcera を再起動しても WebSocket が自動的に再接続するため、OBS 側の手動更新は不要です。
+            ローカルファイル（<code>file://</code>）として読み込むため、OBS を先に起動しても問題ありません。Parcera の起動・再起動時に WebSocket が自動的に再接続します。OBS 側の手動更新は不要です。
           </p>
         </CardContent>
       </Card>

--- a/ui/renderer/components/sections/AdvancedSection.tsx
+++ b/ui/renderer/components/sections/AdvancedSection.tsx
@@ -240,7 +240,7 @@ export const AdvancedSection: React.FC<SectionProps> = ({
           <div className="space-y-4">
             <h4 className="text-sm font-semibold border-b border-border pb-2">STT</h4>
 
-            <FieldRow label="プロバイダー">
+            <FieldRow label="プロバイダー" restartRequired>
               <Select
                 value={settings.stt?.provider ?? 'moonshine'}
                 onValueChange={(val) => updateNested('stt', 'provider', val)}
@@ -266,7 +266,7 @@ export const AdvancedSection: React.FC<SectionProps> = ({
 
             {currentSTTProvider === 'faster_whisper' && (
               <>
-                <FieldRow label="モデル（HuggingFace形式）">
+                <FieldRow label="モデル（HuggingFace形式）" restartRequired>
                   <Input
                     value={settings.stt?.providers?.faster_whisper?.model ?? ''}
                     onChange={(e) => updateProvider('stt', 'faster_whisper', 'model', e.target.value)}
@@ -274,7 +274,7 @@ export const AdvancedSection: React.FC<SectionProps> = ({
                   />
                 </FieldRow>
                 <div className="grid grid-cols-2 gap-4">
-                  <FieldRow label="演算デバイス">
+                  <FieldRow label="演算デバイス" restartRequired>
                     <Select
                       value={settings.stt?.providers?.faster_whisper?.device ?? 'auto'}
                       onValueChange={(v) => updateProvider('stt', 'faster_whisper', 'device', v)}
@@ -287,7 +287,7 @@ export const AdvancedSection: React.FC<SectionProps> = ({
                       </SelectContent>
                     </Select>
                   </FieldRow>
-                  <FieldRow label="量子化">
+                  <FieldRow label="量子化" restartRequired>
                     <Select
                       value={settings.stt?.providers?.faster_whisper?.compute_type ?? 'default'}
                       onValueChange={(v) => updateProvider('stt', 'faster_whisper', 'compute_type', v)}

--- a/ui/renderer/components/sections/AdvancedSection.tsx
+++ b/ui/renderer/components/sections/AdvancedSection.tsx
@@ -102,10 +102,11 @@ export const AdvancedSection: React.FC<SectionProps> = ({
   const frontendPort = (settings.app as any)?.frontend_port || (port + 1);
   const isWindows = api.platform === 'win32';
 
-  // obs.html is a self-contained static page that survives Parcera restarts
-  // via WebSocket reconnection — no page reload required.
+  // obs.html is served by the Python server (port=8676) so it does not depend
+  // on the Tauri localhost plugin. OBS loads it once; WebSocket reconnection
+  // handles Parcera restarts without a manual browser-source refresh.
   const obsAiUrl = `http://localhost:${frontendPort}/?type=ai&obs=1`;
-  const obsUserUrl = `http://localhost:${frontendPort}/obs.html?type=user`;
+  const obsUserUrl = `http://localhost:${port}/obs.html?type=user`;
 
   return (
     <div className="space-y-6">

--- a/ui/renderer/components/sections/AdvancedSection.tsx
+++ b/ui/renderer/components/sections/AdvancedSection.tsx
@@ -58,6 +58,19 @@ const OptionalPackageCheck: React.FC<{ provider: OptionalSTTProvider; port: numb
   );
 };
 
+const ObsUrlRow: React.FC<{ label: string; url: string }> = ({ label, url }) => {
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(url);
+  };
+  return (
+    <div className="flex items-center gap-2">
+      <Label className="w-28 shrink-0 text-xs">{label}</Label>
+      <code className="flex-1 truncate rounded bg-muted px-2 py-1 text-xs font-mono">{url}</code>
+      <Button variant="outline" size="sm" onClick={handleCopy}>コピー</Button>
+    </div>
+  );
+};
+
 export const AdvancedSection: React.FC<SectionProps> = ({
   settings,
   defaultSettings,
@@ -86,7 +99,11 @@ export const AdvancedSection: React.FC<SectionProps> = ({
   const currentSTTProvider = settings.stt?.provider || 'moonshine';
   const currentTTSProvider = settings.tts?.provider || 'aivisspeech';
   const port = settings.app?.port || 8676;
+  const frontendPort = (settings.app as any)?.frontend_port || (port + 1);
   const isWindows = api.platform === 'win32';
+
+  const obsAiUrl = `http://localhost:${frontendPort}/?type=ai&obs=1`;
+  const obsUserUrl = `http://localhost:${frontendPort}/?type=user&obs=1`;
 
   return (
     <div className="space-y-6">
@@ -326,6 +343,20 @@ export const AdvancedSection: React.FC<SectionProps> = ({
           setStatus={setStatus}
         />
       )}
+
+      {/* OBS Browser Source */}
+      <Card>
+        <CardHeader>
+          <CardTitle>OBS Browser Source URL</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            OBS の「ブラウザソース」に以下の URL を貼り付けることで、ウィンドウキャプチャなしにアバターを配信へ組み込めます。
+          </p>
+          <ObsUrlRow label="AI アバター" url={obsAiUrl} />
+          <ObsUrlRow label="User アバター" url={obsUserUrl} />
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/ui/renderer/components/sections/AdvancedSection.tsx
+++ b/ui/renderer/components/sections/AdvancedSection.tsx
@@ -102,8 +102,10 @@ export const AdvancedSection: React.FC<SectionProps> = ({
   const frontendPort = (settings.app as any)?.frontend_port || (port + 1);
   const isWindows = api.platform === 'win32';
 
+  // obs.html is a self-contained static page that survives Parcera restarts
+  // via WebSocket reconnection — no page reload required.
   const obsAiUrl = `http://localhost:${frontendPort}/?type=ai&obs=1`;
-  const obsUserUrl = `http://localhost:${frontendPort}/?type=user&obs=1`;
+  const obsUserUrl = `http://localhost:${frontendPort}/obs.html?type=user`;
 
   return (
     <div className="space-y-6">
@@ -355,6 +357,9 @@ export const AdvancedSection: React.FC<SectionProps> = ({
           </p>
           <ObsUrlRow label="AI アバター" url={obsAiUrl} />
           <ObsUrlRow label="User アバター" url={obsUserUrl} />
+          <p className="text-xs text-muted-foreground">
+            User アバターは独立した静的ページです。Parcera を再起動しても WebSocket が自動的に再接続するため、OBS 側の手動更新は不要です。
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/ui/renderer/components/sections/AdvancedSection.tsx
+++ b/ui/renderer/components/sections/AdvancedSection.tsx
@@ -99,7 +99,7 @@ export const AdvancedSection: React.FC<SectionProps> = ({
   const currentSTTProvider = settings.stt?.provider || 'moonshine';
   const currentTTSProvider = settings.tts?.provider || 'aivisspeech';
   const port = settings.app?.port || 8676;
-  const frontendPort = (settings.app as any)?.frontend_port || (port + 1);
+  const frontendPort = settings.app?.frontend_port ?? (port + 1);
   const isWindows = api.platform === 'win32';
 
   // Fetch obs.html's file:// URI from Python so OBS can load the page even

--- a/ui/renderer/components/sections/CharacterSection.tsx
+++ b/ui/renderer/components/sections/CharacterSection.tsx
@@ -221,7 +221,7 @@ export const CharacterSection: React.FC<SectionProps> = ({
           <CardTitle>声</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <FieldRow label="TTSプロバイダー">
+          <FieldRow label="TTSプロバイダー" restartRequired>
             <Select
               value={settings.tts?.provider || 'aivisspeech'}
               onValueChange={(val) => updateNested('tts', 'provider', val)}

--- a/ui/renderer/components/sections/DeveloperSection.tsx
+++ b/ui/renderer/components/sections/DeveloperSection.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { api } from '../../lib/api';
 import { SectionProps } from './types';
-import { FieldRow } from './shared';
+import { FieldRow, RestartBadge } from './shared';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
@@ -160,13 +160,12 @@ export const DeveloperSection: React.FC<SectionProps> = ({
           <CardTitle>システム設定</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
-          <FieldRow label="WebSocketポート番号">
+          <FieldRow label="WebSocketポート番号" restartRequired>
             <Input
               type="number"
               value={settings.app?.port ?? defaultSettings?.app?.port ?? 8676}
               onChange={(e) => updateNested('app', 'port', Number(e.target.value))}
             />
-            <p className="text-xs text-muted-foreground mt-1">変更後は再起動が必要です。</p>
           </FieldRow>
 
           <FieldRow label="内部音声サンプリングレート (Hz)">
@@ -189,7 +188,7 @@ export const DeveloperSection: React.FC<SectionProps> = ({
 
           <div className="flex items-center justify-between">
             <div>
-              <Label>GPUアクセラレーション</Label>
+              <Label>GPUアクセラレーション<RestartBadge /></Label>
               <p className="text-xs text-muted-foreground">OBSキャプチャで問題がある場合はOFFにして再起動。</p>
             </div>
             <Switch

--- a/ui/renderer/components/sections/MicInputSection.tsx
+++ b/ui/renderer/components/sections/MicInputSection.tsx
@@ -18,25 +18,16 @@ export const MicInputSection: React.FC<SectionProps> = ({
   ]);
 
   useEffect(() => {
-    const fetchDevices = async () => {
-      try {
-        const all = await navigator.mediaDevices.enumerateDevices();
-        const audioInputs = all
-          .filter((d) => d.kind === 'audioinput')
-          .map((d) => ({ value: d.deviceId, label: d.label || 'Microphone' }))
-          .filter((v, i, a) => v.value && a.findIndex((t) => t.value === v.value) === i);
-        setDevices([
-          { value: 'default', label: 'システムデフォルト' },
-          ...audioInputs.filter((d) => d.value !== 'default' && d.value !== ''),
-        ]);
-      } catch {
-        // silently ignore — device list stays as default
-      }
-    };
-    fetchDevices();
-    navigator.mediaDevices.addEventListener('devicechange', fetchDevices);
-    return () => navigator.mediaDevices.removeEventListener('devicechange', fetchDevices);
-  }, []);
+    const port = settings.app?.port ?? 8676;
+    fetch(`http://127.0.0.1:${port}/config/mic-devices`)
+      .then((r) => r.json())
+      .then((list: { value: string; label: string }[]) => {
+        if (list.length > 0) {
+          setDevices([{ value: 'default', label: 'システムデフォルト' }, ...list]);
+        }
+      })
+      .catch(() => {/* server not yet ready — keep default only */});
+  }, [settings.app?.port]);
 
   const volumeDb = settings.vad?.volume_db_threshold ?? defaultSettings?.vad?.volume_db_threshold ?? -20;
   const silenceDuration = settings.vad?.silence_duration_threshold ?? defaultSettings?.vad?.silence_duration_threshold ?? 0.8;

--- a/ui/renderer/components/sections/shared.tsx
+++ b/ui/renderer/components/sections/shared.tsx
@@ -4,13 +4,22 @@ import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { Slider } from '../ui/slider';
 
+export const RestartBadge: React.FC = () => (
+  <span className="inline-flex items-center align-middle ml-1.5 text-[10px] text-muted-foreground/50 border border-muted-foreground/20 rounded px-1 py-[1px]">
+    要再起動
+  </span>
+);
+
 export const FieldRow: React.FC<{
   label: string;
   htmlFor?: string;
+  restartRequired?: boolean;
   children: React.ReactNode;
-}> = ({ label, htmlFor, children }) => (
+}> = ({ label, htmlFor, restartRequired, children }) => (
   <div className="space-y-1.5">
-    <Label htmlFor={htmlFor} className="text-sm font-medium">{label}</Label>
+    <Label htmlFor={htmlFor} className="text-sm font-medium">
+      {label}{restartRequired && <RestartBadge />}
+    </Label>
     {children}
   </div>
 );

--- a/ui/renderer/components/settings/WindowSettingsSection.tsx
+++ b/ui/renderer/components/settings/WindowSettingsSection.tsx
@@ -27,6 +27,7 @@ export const WindowSettingsSection: React.FC<WindowSettingsSectionProps> = ({
   const winParams = settings.app?.windows?.[type] || {};
   const defaultWinParams = defaultSettings?.app?.windows?.[type] || {};
   const labelPrefix = type === 'user' ? 'USER' : 'AI';
+  const isVisible = winParams.visible ?? true;
 
   const updateWinParam = (key: string, value: unknown) => {
     updateNested('app', 'windows', {
@@ -35,80 +36,99 @@ export const WindowSettingsSection: React.FC<WindowSettingsSectionProps> = ({
     });
   };
 
+  const handleVisibleChange = async (checked: boolean) => {
+    updateWinParam('visible', checked);
+    await api.setWindowVisible(type, checked);
+  };
+
   return (
     <div className="space-y-3">
       <h5 className="text-sm font-semibold text-foreground">{labelPrefix}ウィンドウ</h5>
 
       <div className="flex items-center justify-between">
-        <Label className="text-sm">常に最前面に表示する</Label>
+        <Label className="text-sm">Tauriウィンドウを表示する</Label>
         <Switch
-          checked={winParams.alwaysOnTop ?? false}
-          onCheckedChange={(checked) => updateWinParam('alwaysOnTop', checked)}
+          checked={isVisible}
+          onCheckedChange={handleVisibleChange}
         />
       </div>
 
-      <div className="flex items-center justify-between">
-        <Label className="text-sm">起動時にウィンドウ位置をロックする</Label>
-        <Switch
-          checked={winParams.locked ?? defaultWinParams.locked ?? false}
-          onCheckedChange={(checked) => updateWinParam('locked', checked)}
-        />
-      </div>
+      <div className={`space-y-3 ${!isVisible ? 'pointer-events-none opacity-40' : ''}`}>
+        <div className="flex items-center justify-between">
+          <Label className="text-sm">常に最前面に表示する</Label>
+          <Switch
+            checked={winParams.alwaysOnTop ?? false}
+            onCheckedChange={(checked) => updateWinParam('alwaysOnTop', checked)}
+            disabled={!isVisible}
+          />
+        </div>
 
-      <Button
-        variant="outline"
-        size="sm"
-        className="w-full text-xs"
-        onClick={async () => {
-          const bounds = await api.getAvatarWindowBounds(type);
-          if (bounds) {
-            updateNested('app', 'windows', {
-              ...settings.app?.windows,
-              [type]: { ...winParams, x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height },
-            });
-          } else {
-            setStatus?.({ message: `${labelPrefix}ウィンドウが見つかりません`, type: 'error' });
-          }
-        }}
-      >
-        現在の{labelPrefix}ウィンドウの座標・サイズを取得
-      </Button>
+        <div className="flex items-center justify-between">
+          <Label className="text-sm">起動時にウィンドウ位置をロックする</Label>
+          <Switch
+            checked={winParams.locked ?? defaultWinParams.locked ?? false}
+            onCheckedChange={(checked) => updateWinParam('locked', checked)}
+            disabled={!isVisible}
+          />
+        </div>
 
-      <div className="grid grid-cols-2 gap-2">
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">X座標</Label>
-          <Input type="number" value={winParams.x ?? defaultWinParams.x ?? 0} onChange={(e) => updateWinParam('x', Number(e.target.value))} />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">Y座標</Label>
-          <Input type="number" value={winParams.y ?? defaultWinParams.y ?? 0} onChange={(e) => updateWinParam('y', Number(e.target.value))} />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">幅</Label>
-          <Input type="number" value={winParams.width ?? defaultWinParams.width ?? 300} onChange={(e) => updateWinParam('width', Number(e.target.value))} />
-        </div>
-        <div className="space-y-1">
-          <Label className="text-xs text-muted-foreground">高さ</Label>
-          <Input type="number" value={winParams.height ?? defaultWinParams.height ?? 300} onChange={(e) => updateWinParam('height', Number(e.target.value))} />
-        </div>
-      </div>
-
-      <div className="space-y-1.5">
-        <Label className="text-xs text-muted-foreground">操作ボタンの表示位置</Label>
-        <Select
-          value={winParams.control_corner ?? defaultWinParams.control_corner ?? 'bottom-right'}
-          onValueChange={(val) => updateWinParam('control_corner', val)}
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full text-xs"
+          disabled={!isVisible}
+          onClick={async () => {
+            const bounds = await api.getAvatarWindowBounds(type);
+            if (bounds) {
+              updateNested('app', 'windows', {
+                ...settings.app?.windows,
+                [type]: { ...winParams, x: bounds.x, y: bounds.y, width: bounds.width, height: bounds.height },
+              });
+            } else {
+              setStatus?.({ message: `${labelPrefix}ウィンドウが見つかりません`, type: 'error' });
+            }
+          }}
         >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="top-left">左上</SelectItem>
-            <SelectItem value="top-right">右上</SelectItem>
-            <SelectItem value="bottom-left">左下</SelectItem>
-            <SelectItem value="bottom-right">右下</SelectItem>
-          </SelectContent>
-        </Select>
+          現在の{labelPrefix}ウィンドウの座標・サイズを取得
+        </Button>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">X座標</Label>
+            <Input type="number" disabled={!isVisible} value={winParams.x ?? defaultWinParams.x ?? 0} onChange={(e) => updateWinParam('x', Number(e.target.value))} />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">Y座標</Label>
+            <Input type="number" disabled={!isVisible} value={winParams.y ?? defaultWinParams.y ?? 0} onChange={(e) => updateWinParam('y', Number(e.target.value))} />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">幅</Label>
+            <Input type="number" disabled={!isVisible} value={winParams.width ?? defaultWinParams.width ?? 300} onChange={(e) => updateWinParam('width', Number(e.target.value))} />
+          </div>
+          <div className="space-y-1">
+            <Label className="text-xs text-muted-foreground">高さ</Label>
+            <Input type="number" disabled={!isVisible} value={winParams.height ?? defaultWinParams.height ?? 300} onChange={(e) => updateWinParam('height', Number(e.target.value))} />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <Label className="text-xs text-muted-foreground">操作ボタンの表示位置</Label>
+          <Select
+            value={winParams.control_corner ?? defaultWinParams.control_corner ?? 'bottom-right'}
+            onValueChange={(val) => updateWinParam('control_corner', val)}
+            disabled={!isVisible}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="top-left">左上</SelectItem>
+              <SelectItem value="top-right">右上</SelectItem>
+              <SelectItem value="bottom-left">左下</SelectItem>
+              <SelectItem value="bottom-right">右下</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
     </div>
   );

--- a/ui/renderer/components/settings/WindowSettingsSection.tsx
+++ b/ui/renderer/components/settings/WindowSettingsSection.tsx
@@ -36,9 +36,8 @@ export const WindowSettingsSection: React.FC<WindowSettingsSectionProps> = ({
     });
   };
 
-  const handleVisibleChange = async (checked: boolean) => {
+  const handleVisibleChange = (checked: boolean) => {
     updateWinParam('visible', checked);
-    await api.setWindowVisible(type, checked);
   };
 
   return (
@@ -46,7 +45,7 @@ export const WindowSettingsSection: React.FC<WindowSettingsSectionProps> = ({
       <h5 className="text-sm font-semibold text-foreground">{labelPrefix}ウィンドウ</h5>
 
       <div className="flex items-center justify-between">
-        <Label className="text-sm">Tauriウィンドウを表示する</Label>
+        <Label className="text-sm">アバターウィンドウを表示する</Label>
         <Switch
           checked={isVisible}
           onCheckedChange={handleVisibleChange}

--- a/ui/renderer/lib/api.ts
+++ b/ui/renderer/lib/api.ts
@@ -1,4 +1,7 @@
 import type { ParceraAPI } from './bridge';
 import { api as tauriApi } from './tauri-bridge';
+import { obsApi } from './obs-bridge';
 
-export const api: ParceraAPI = tauriApi;
+const _isObs = new URLSearchParams(window.location.search).get('obs') === '1';
+
+export const api: ParceraAPI = _isObs ? obsApi : tauriApi;

--- a/ui/renderer/lib/api.ts
+++ b/ui/renderer/lib/api.ts
@@ -2,6 +2,6 @@ import type { ParceraAPI } from './bridge';
 import { api as tauriApi } from './tauri-bridge';
 import { obsApi } from './obs-bridge';
 
-const _isObs = new URLSearchParams(window.location.search).get('obs') === '1';
+export const isObs = new URLSearchParams(window.location.search).get('obs') === '1';
 
-export const api: ParceraAPI = _isObs ? obsApi : tauriApi;
+export const api: ParceraAPI = isObs ? obsApi : tauriApi;

--- a/ui/renderer/lib/audio.ts
+++ b/ui/renderer/lib/audio.ts
@@ -54,6 +54,26 @@ let currentAnalyserSource: AudioNode | null = null;
 const fData = new Float32Array(FFT_SIZE / 2);
 const tData = new Float32Array(FFT_SIZE);
 
+// --- External Lipsync Override (OBS user mode) ---
+// When set, visual.ts reads these instead of analyzing browser AudioContext.
+let _externalEnv: number | null = null;
+let _externalVowel: Vowel | null = null;
+
+export function setExternalLipsync(vowel: Vowel | null, amplitude: number): void {
+  _externalEnv = amplitude;
+  _externalVowel = vowel;
+}
+
+export function clearExternalLipsync(): void {
+  _externalEnv = null;
+  _externalVowel = null;
+}
+
+export function getExternalLipsync(): { env: number; vowel: Vowel | null } | null {
+  if (_externalEnv === null) return null;
+  return { env: _externalEnv, vowel: _externalVowel };
+}
+
 // --- Adaptive Normalization State ---
 const normalization = {
   noise: 1e-4,   // Tracked noise floor (adapts slowly)

--- a/ui/renderer/lib/audio.ts
+++ b/ui/renderer/lib/audio.ts
@@ -54,24 +54,36 @@ let currentAnalyserSource: AudioNode | null = null;
 const fData = new Float32Array(FFT_SIZE / 2);
 const tData = new Float32Array(FFT_SIZE);
 
-// --- External Lipsync Override (OBS user mode) ---
-// When set, visual.ts reads these instead of analyzing browser AudioContext.
-let _externalEnv: number | null = null;
-let _externalVowel: Vowel | null = null;
+// --- External Lipsync Override (Python MicAnalyzer driven) ---
+// Used by both OBS browser source and the Tauri User Window.
+// visual.ts reads these instead of analyzing browser AudioContext.
+//
+// rawAmplitude: raw linear RMS from Python — shown on the dB peak meter so
+//   users can calibrate vad.volume_db_threshold against what they see.
+// env: lipsync activation value — set above TALK_THRESHOLD when Python's
+//   VAD says "speaking", otherwise equals rawAmplitude (stays low = no lip).
+interface _ExternalState {
+  env: number;
+  rawAmplitude: number;
+  vowel: Vowel | null;
+}
+let _externalLipsync: _ExternalState | null = null;
 
-export function setExternalLipsync(vowel: Vowel | null, amplitude: number): void {
-  _externalEnv = amplitude;
-  _externalVowel = vowel;
+export function setExternalLipsync(vowel: Vowel | null, amplitude: number, speaking: boolean): void {
+  _externalLipsync = {
+    // When Python VAD is active, drive env above TALK_THRESHOLD so mouth animates.
+    env: speaking ? Math.max(amplitude, TALK_THRESHOLD + 0.01) : amplitude,
+    rawAmplitude: amplitude,
+    vowel,
+  };
 }
 
 export function clearExternalLipsync(): void {
-  _externalEnv = null;
-  _externalVowel = null;
+  _externalLipsync = null;
 }
 
-export function getExternalLipsync(): { env: number; vowel: Vowel | null } | null {
-  if (_externalEnv === null) return null;
-  return { env: _externalEnv, vowel: _externalVowel };
+export function getExternalLipsync(): _ExternalState | null {
+  return _externalLipsync;
 }
 
 // --- Adaptive Normalization State ---

--- a/ui/renderer/lib/bridge.ts
+++ b/ui/renderer/lib/bridge.ts
@@ -43,6 +43,7 @@ export interface ParceraAPI {
   getWindowBounds(): Promise<Rect | null>;
   saveWindowBounds(type: 'user' | 'ai'): Promise<OpResult>;
   getAvatarWindowBounds(type: 'user' | 'ai'): Promise<Rect | null>;
+  setWindowVisible(type: 'user' | 'ai', visible: boolean): Promise<void>;
 
   // FS / Dialog
   selectDirectory(currentPath?: string): Promise<string | null>;

--- a/ui/renderer/lib/bridge.ts
+++ b/ui/renderer/lib/bridge.ts
@@ -44,6 +44,7 @@ export interface ParceraAPI {
   saveWindowBounds(type: 'user' | 'ai'): Promise<OpResult>;
   getAvatarWindowBounds(type: 'user' | 'ai'): Promise<Rect | null>;
   setWindowVisible(type: 'user' | 'ai', visible: boolean): Promise<void>;
+  setWindowAlwaysOnTop(type: 'user' | 'ai', alwaysOnTop: boolean): Promise<void>;
 
   // FS / Dialog
   selectDirectory(currentPath?: string): Promise<string | null>;

--- a/ui/renderer/lib/bridge.ts
+++ b/ui/renderer/lib/bridge.ts
@@ -10,7 +10,7 @@ export type TwitchStatus = {
   session_id?: string;
 };
 
-export type OpResult = { success: boolean; error?: string };
+export type OpResult = { success: boolean; error?: string; restart_required?: boolean };
 
 export type DownloadProgress = {
   status: 'downloading' | 'complete' | 'error';

--- a/ui/renderer/lib/comm.ts
+++ b/ui/renderer/lib/comm.ts
@@ -7,7 +7,7 @@
  */
 import { state, logStatus } from './state';
 import type { ServerMessage } from './state';
-import { getContext, getAnalyser, connectToAnalyser, setExternalLipsync } from './audio';
+import { getContext, getAnalyser, connectToAnalyser, setExternalLipsync, clearExternalLipsync } from './audio';
 import type { Vowel } from './audio';
 import processorUrl from './pcm-processor.js?url';
 
@@ -329,6 +329,7 @@ export function startLipsyncWebSocket(): void {
   };
 
   lipsyncSocket.onclose = () => {
+    clearExternalLipsync(); // stop mouth animation while disconnected
     logStatus('OBS Lipsync Disconnected');
     setTimeout(startLipsyncWebSocket, 3000);
   };

--- a/ui/renderer/lib/comm.ts
+++ b/ui/renderer/lib/comm.ts
@@ -290,7 +290,8 @@ export function startLipsyncWebSocket(): void {
       if (data.type === 'user_lipsync') {
         const vowel = (data.vowel as Vowel) || null;
         const amplitude = typeof data.amplitude === 'number' ? data.amplitude : 0;
-        setExternalLipsync(vowel, amplitude);
+        const speaking = typeof data.speaking === 'boolean' ? data.speaking : false;
+        setExternalLipsync(vowel, amplitude, speaking);
       }
     } catch { /* skip malformed */ }
   };

--- a/ui/renderer/lib/comm.ts
+++ b/ui/renderer/lib/comm.ts
@@ -259,6 +259,37 @@ let currentWorkletNode: AudioWorkletNode | null = null;
 let micSetupGen = 0;
 
 // =====================
+// OBS Server Watcher
+// =====================
+
+/**
+ * In OBS browser-source mode, poll the Python server health endpoint.
+ * When the server goes down and comes back (i.e. Parcera was restarted),
+ * reload the page so every WebSocket and settings fetch starts fresh.
+ *
+ * The watcher runs for the lifetime of the page — no cleanup needed.
+ */
+export function startObsServerWatcher(): void {
+  const port = state.settings.app?.port || DEFAULT_PORT;
+  let wasDown = false;
+
+  const tick = async () => {
+    const healthy = await checkServerHealth(port);
+    if (!healthy) {
+      wasDown = true;
+    } else if (wasDown) {
+      // Server just recovered — reload to re-init WS, settings, and audio.
+      location.reload();
+      return;
+    }
+    setTimeout(tick, 3000);
+  };
+
+  // Kick off the first check after a short delay to avoid racing with startup.
+  setTimeout(tick, 5000);
+}
+
+// =====================
 // OBS User Lipsync WebSocket
 // =====================
 let lipsyncSocket: WebSocket | null = null;

--- a/ui/renderer/lib/comm.ts
+++ b/ui/renderer/lib/comm.ts
@@ -2,11 +2,13 @@
  * Parcera: Communication Manager
  *
  * WebSocket connection to the Python AI server, microphone streaming
- * (PCM via AudioWorklet → Base64), and sequential audio playback queue.
+ * (PCM via AudioWorklet → Base64), sequential audio playback queue,
+ * and OBS user-avatar lipsync WS subscription.
  */
 import { state, logStatus } from './state';
 import type { ServerMessage } from './state';
-import { getContext, getAnalyser, connectToAnalyser } from './audio';
+import { getContext, getAnalyser, connectToAnalyser, setExternalLipsync } from './audio';
+import type { Vowel } from './audio';
 import processorUrl from './pcm-processor.js?url';
 
 // --- Constants ---
@@ -255,6 +257,53 @@ let currentWorkletNode: AudioWorkletNode | null = null;
 // while `await addModule` is pending, the older call self-aborts after the
 // await rather than creating a stale worklet that double-sends PCM to Python.
 let micSetupGen = 0;
+
+// =====================
+// OBS User Lipsync WebSocket
+// =====================
+let lipsyncSocket: WebSocket | null = null;
+
+/**
+ * Open a WebSocket session for OBS user-avatar mode.
+ * Subscribes to ``user_lipsync`` events from Python MicAnalyzer and feeds
+ * them into the external lipsync override in audio.ts so visual.ts can
+ * drive mouth animation without a browser mic.
+ */
+export function startLipsyncWebSocket(): void {
+  const port = state.settings.app?.port || DEFAULT_PORT;
+  const wsUrl = buildWsUrl(port);
+
+  if (lipsyncSocket && (lipsyncSocket.readyState === WebSocket.OPEN || lipsyncSocket.readyState === WebSocket.CONNECTING)) {
+    return;
+  }
+
+  lipsyncSocket = new WebSocket(wsUrl);
+
+  lipsyncSocket.onopen = () => {
+    logStatus('OBS Lipsync Connected');
+    lipsyncSocket?.send(JSON.stringify({ type: 'start', session_id: 'obs-user-session' }));
+  };
+
+  lipsyncSocket.onmessage = (event: MessageEvent) => {
+    try {
+      const data = JSON.parse(event.data as string);
+      if (data.type === 'user_lipsync') {
+        const vowel = (data.vowel as Vowel) || null;
+        const amplitude = typeof data.amplitude === 'number' ? data.amplitude : 0;
+        setExternalLipsync(vowel, amplitude);
+      }
+    } catch { /* skip malformed */ }
+  };
+
+  lipsyncSocket.onclose = () => {
+    logStatus('OBS Lipsync Disconnected');
+    setTimeout(startLipsyncWebSocket, 3000);
+  };
+
+  lipsyncSocket.onerror = () => {
+    logStatus('OBS Lipsync Error');
+  };
+}
 
 export async function setupMicStreaming(source: MediaStreamAudioSourceNode): Promise<void> {
   const audioContext = getContext();

--- a/ui/renderer/lib/comm.ts
+++ b/ui/renderer/lib/comm.ts
@@ -281,7 +281,8 @@ export function startLipsyncWebSocket(): void {
 
   lipsyncSocket.onopen = () => {
     logStatus('OBS Lipsync Connected');
-    lipsyncSocket?.send(JSON.stringify({ type: 'start', session_id: 'obs-user-session' }));
+    const sessionId = `lipsync-${Math.random().toString(36).slice(2, 9)}`;
+    lipsyncSocket?.send(JSON.stringify({ type: 'start', session_id: sessionId }));
   };
 
   lipsyncSocket.onmessage = (event: MessageEvent) => {

--- a/ui/renderer/lib/hooks/useAvatar.ts
+++ b/ui/renderer/lib/hooks/useAvatar.ts
@@ -4,7 +4,7 @@ import { state, logStatus } from '../state';
 import type { AvatarConfig, ParceraSettings } from '../state';
 import { initAudioContext, getContext, setNoiseGateDb } from '../audio';
 import { initVisual } from '../visual';
-import { startWebSocket, startLipsyncWebSocket } from '../comm';
+import { startWebSocket, startLipsyncWebSocket, startObsServerWatcher } from '../comm';
 
 const _isObs = new URLSearchParams(window.location.search).get('obs') === '1';
 
@@ -70,6 +70,7 @@ export function useAvatar() {
       // OBS mode: Python handles audio capture; browser only needs WS for visuals.
       if (_isObs) {
         logStatus('OBS Mode Active');
+        startObsServerWatcher();
         if (state.avatarType === 'ai') {
           // AI avatar in OBS: standard WS for TTS audio playback.
           initAudioContext();

--- a/ui/renderer/lib/hooks/useAvatar.ts
+++ b/ui/renderer/lib/hooks/useAvatar.ts
@@ -11,7 +11,6 @@ const _isObs = new URLSearchParams(window.location.search).get('obs') === '1';
 export function useAvatar() {
   const avatarImageRef = useRef<HTMLImageElement>(null);
   const statusDebugRef = useRef<HTMLDivElement>(null);
-  const micTrackRef = useRef<MediaStreamTrack | null>(null);
   const [visible, setVisible] = useState(true);
   const [viewMode, setViewMode] = useState<'standard' | 'wide'>('standard');
   const [isLocked, setIsLocked] = useState(false);
@@ -165,9 +164,6 @@ export function useAvatar() {
 
       const newMuted = settings.vad?.start_muted ?? false;
       setIsMuted(newMuted);
-      if (micTrackRef.current) {
-        micTrackRef.current.enabled = !newMuted;
-      }
 
       const winConf = settings.app?.windows?.[state.avatarType];
       if (winConf?.control_corner) {
@@ -205,7 +201,6 @@ export function useAvatar() {
     e.stopPropagation();
     const nextMuted = !isMuted;
     setIsMuted(nextMuted);
-    if (micTrackRef.current) micTrackRef.current.enabled = !nextMuted;
     logStatus(nextMuted ? 'Muted' : 'Mic Active');
     await api.updateSetting('vad.start_muted', nextMuted);
   };

--- a/ui/renderer/lib/hooks/useAvatar.ts
+++ b/ui/renderer/lib/hooks/useAvatar.ts
@@ -4,7 +4,9 @@ import { state, logStatus } from '../state';
 import type { AvatarConfig, ParceraSettings } from '../state';
 import { initAudioContext, getContext, setNoiseGateDb, connectToAnalyser } from '../audio';
 import { initVisual } from '../visual';
-import { startWebSocket, setupMicStreaming } from '../comm';
+import { startWebSocket, startLipsyncWebSocket } from '../comm';
+
+const _isObs = new URLSearchParams(window.location.search).get('obs') === '1';
 
 export function useAvatar() {
   const avatarImageRef = useRef<HTMLImageElement>(null);
@@ -64,6 +66,30 @@ export function useAvatar() {
 
     const startup = async () => {
       if (!active) return;
+
+      // OBS mode: Python handles audio capture; browser only needs WS for visuals.
+      if (_isObs) {
+        logStatus('OBS Mode Active');
+        if (state.avatarType === 'ai') {
+          // AI avatar in OBS: standard WS for TTS audio playback.
+          initAudioContext();
+          const ctx = getContext();
+          if (ctx?.state === 'suspended') {
+            await Promise.race([
+              ctx.resume(),
+              new Promise<void>(resolve => setTimeout(resolve, 500)),
+            ]).catch(() => {});
+          }
+          startWebSocket();
+        } else {
+          // User avatar in OBS: WS lipsync subscription (no getUserMedia).
+          startLipsyncWebSocket();
+        }
+        if (active) logStatus('OBS Live');
+        return;
+      }
+
+      // Standard Tauri mode
       logStatus('Initializing Audio...');
       initAudioContext();
       const ctx = getContext();
@@ -75,6 +101,14 @@ export function useAvatar() {
         ]).catch(() => {});
       }
 
+      if (state.avatarType === 'ai') {
+        // AI avatar: Python sounddevice handles STT; browser only plays TTS audio.
+        startWebSocket();
+        if (active) logStatus('AI System Live');
+        return;
+      }
+
+      // User avatar: getUserMedia for local visual lipsync only.
       try {
         if (micTrackRef.current) {
           micTrackRef.current.stop();
@@ -114,13 +148,8 @@ export function useAvatar() {
           await ctx.resume().catch(() => {});
         }
 
-        if (state.avatarType === 'user') {
-          connectToAnalyser(micSource);
-          logStatus('User Mic Active');
-        } else {
-          await setupMicStreaming(micSource);
-          logStatus('AI System Listening...');
-        }
+        connectToAnalyser(micSource);
+        logStatus('User Mic Active');
       } catch (err) {
         console.error('Mic Access Error:', err);
         if (micId && micId !== 'default') {
@@ -132,7 +161,6 @@ export function useAvatar() {
         logStatus('Mic Error');
       }
 
-      if (state.avatarType === 'ai') startWebSocket();
       if (active) logStatus('System Live');
     };
 

--- a/ui/renderer/lib/hooks/useAvatar.ts
+++ b/ui/renderer/lib/hooks/useAvatar.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { api } from '../api';
 import { state, logStatus } from '../state';
 import type { AvatarConfig, ParceraSettings } from '../state';
-import { initAudioContext, getContext, setNoiseGateDb, connectToAnalyser } from '../audio';
+import { initAudioContext, getContext, setNoiseGateDb } from '../audio';
 import { initVisual } from '../visual';
 import { startWebSocket, startLipsyncWebSocket } from '../comm';
 
@@ -90,78 +90,27 @@ export function useAvatar() {
       }
 
       // Standard Tauri mode
-      logStatus('Initializing Audio...');
-      initAudioContext();
-      const ctx = getContext();
-      if (!ctx || ctx.state === 'closed') return;
-      if (ctx.state === 'suspended') {
-        await Promise.race([
-          ctx.resume(),
-          new Promise<void>(resolve => setTimeout(resolve, 500)),
-        ]).catch(() => {});
-      }
-
       if (state.avatarType === 'ai') {
         // AI avatar: Python sounddevice handles STT; browser only plays TTS audio.
+        logStatus('Initializing Audio...');
+        initAudioContext();
+        const ctx = getContext();
+        if (!ctx || ctx.state === 'closed') return;
+        if (ctx.state === 'suspended') {
+          await Promise.race([
+            ctx.resume(),
+            new Promise<void>(resolve => setTimeout(resolve, 500)),
+          ]).catch(() => {});
+        }
         startWebSocket();
         if (active) logStatus('AI System Live');
         return;
       }
 
-      // User avatar: getUserMedia for local visual lipsync only.
-      try {
-        if (micTrackRef.current) {
-          micTrackRef.current.stop();
-        }
-
-        const constraints: MediaStreamConstraints = {
-          audio: {
-            echoCancellation: true,
-            noiseSuppression: true,
-            autoGainControl: true,
-            sampleRate: 16000,
-            channelCount: 1,
-            deviceId: micId && micId !== 'default' ? { exact: micId } : undefined
-          }
-        };
-
-        const stream = await navigator.mediaDevices.getUserMedia(constraints);
-        const track = stream.getAudioTracks()[0];
-        micTrackRef.current = track;
-
-        const s = await api.getSettings();
-        const initialMute = s.vad?.start_muted ?? false;
-        const winConf = s.app?.windows?.[state.avatarType];
-
-        if (winConf?.locked) {
-          setIsLocked(true);
-        }
-        if (winConf?.control_corner) setControlCorner(winConf.control_corner);
-
-        setIsMuted(initialMute);
-        track.enabled = !initialMute;
-
-        const micSource = ctx.createMediaStreamSource(stream);
-        // Connecting a MediaStreamSource sometimes unblocks suspended AudioContext
-        // on macOS WKWebView — attempt resume again after mic is granted.
-        if (ctx.state === 'suspended') {
-          await ctx.resume().catch(() => {});
-        }
-
-        connectToAnalyser(micSource);
-        logStatus('User Mic Active');
-      } catch (err) {
-        console.error('Mic Access Error:', err);
-        if (micId && micId !== 'default') {
-          console.warn('[Parcera] Specific mic failed, falling back to default...');
-          logStatus('Mic Fallback');
-          setMicId('default');
-          return;
-        }
-        logStatus('Mic Error');
-      }
-
-      if (active) logStatus('System Live');
+      // User avatar: Python MicAnalyzer is the authoritative audio source.
+      // Subscribe to its lipsync WS events — no getUserMedia needed.
+      startLipsyncWebSocket();
+      if (active) logStatus('User Live');
     };
 
     startup();

--- a/ui/renderer/lib/hooks/useAvatar.ts
+++ b/ui/renderer/lib/hooks/useAvatar.ts
@@ -1,12 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
-import { api } from '../api';
+import { api, isObs } from '../api';
 import { state, logStatus } from '../state';
 import type { AvatarConfig, ParceraSettings } from '../state';
 import { initAudioContext, getContext, setNoiseGateDb } from '../audio';
 import { initVisual } from '../visual';
 import { startWebSocket, startLipsyncWebSocket, startObsServerWatcher } from '../comm';
 
-const _isObs = new URLSearchParams(window.location.search).get('obs') === '1';
+const _isObs = isObs;
 
 export function useAvatar() {
   const avatarImageRef = useRef<HTMLImageElement>(null);

--- a/ui/renderer/lib/hooks/useAvatar.ts
+++ b/ui/renderer/lib/hooks/useAvatar.ts
@@ -124,6 +124,8 @@ export function useAvatar() {
       avatarImageRef.current.src = src.replace('/e.png', '/a.png');
     } else if (src.endsWith('/o.png')) {
       avatarImageRef.current.src = src.replace('/o.png', '/u.png');
+    } else if (!src.endsWith('/base.png')) {
+      avatarImageRef.current.src = src.replace(/[^/]+\.png$/, 'base.png');
     } else {
       avatarImageRef.current.style.opacity = '0.5';
     }

--- a/ui/renderer/lib/obs-bridge.ts
+++ b/ui/renderer/lib/obs-bridge.ts
@@ -1,0 +1,93 @@
+/**
+ * OBS Browser Source API Bridge
+ *
+ * Implements ParceraAPI without any Tauri IPC, so the page can run inside
+ * OBS's browser source (which has no access to __TAURI_INTERNALS__).
+ *
+ * Python port derivation: frontend is served at http://localhost:{F}/
+ * The Python sidecar always listens on port F-1 (e.g. F=8677 → Python=8676).
+ */
+import type { ParceraAPI, Rect, LogEntry, OpResult, TwitchStatus, DownloadProgress } from './bridge';
+import type { ParceraSettings } from '../../shared/types';
+
+function getPythonPort(): number {
+  const frontendPort = parseInt(window.location.port, 10);
+  return frontendPort > 1 ? frontendPort - 1 : 8676;
+}
+
+function pythonUrl(path: string): string {
+  const port = getPythonPort();
+  return `http://127.0.0.1:${port}${path.startsWith('/') ? path : '/' + path}`;
+}
+
+const noop = (): void => {};
+const noopPromise = <T>(val: T) => (): Promise<T> => Promise.resolve(val);
+const noopUnsubscribe = () => noop;
+
+export const obsApi: ParceraAPI = {
+  platform: 'obs',
+
+  // Settings — fetched from Python HTTP endpoint
+  getSettings: async (): Promise<ParceraSettings> => {
+    const res = await fetch(pythonUrl('/config/settings'));
+    if (!res.ok) throw new Error(`GET /config/settings failed: ${res.status}`);
+    return res.json();
+  },
+  getDefaultSettings: async (): Promise<ParceraSettings> => {
+    // Default settings are not available in OBS mode; return empty object.
+    return {};
+  },
+  saveSettings: noopPromise({ success: false, error: 'OBS mode: read-only' } as OpResult),
+  updateSetting: noopPromise({ success: false, error: 'OBS mode: read-only' } as OpResult),
+  reloadSettings: async (): Promise<ParceraSettings> => obsApi.getSettings(),
+  onSettingsChanged: (_cb) => noop,
+
+  // Window — no-ops (OBS controls the window)
+  resizeWindow: noop,
+  setResizable: noop,
+  closeWindow: noop,
+  getWindowBounds: noopPromise(null as Rect | null),
+  saveWindowBounds: noopPromise({ success: false } as OpResult),
+  getAvatarWindowBounds: noopPromise(null as Rect | null),
+
+  // FS / Dialog — no-ops
+  selectDirectory: noopPromise(null as string | null),
+  resolveLocalPath: (filePath: string): string => {
+    if (filePath.startsWith('assets/') || filePath.startsWith('/assets/')) {
+      return filePath.startsWith('/') ? filePath.slice(1) : filePath;
+    }
+    return filePath;
+  },
+
+  // Logs — not accessible in OBS mode
+  getLogHistory: noopPromise([] as LogEntry[]),
+  onLogMessage: noopUnsubscribe,
+
+  // Models — forward to Python backend
+  checkModelCached: async (modelName, port) => {
+    const p = port ?? getPythonPort();
+    const res = await fetch(`http://127.0.0.1:${p}/models/check?name=${encodeURIComponent(modelName)}`);
+    const data = await res.json();
+    return data.cached as boolean;
+  },
+  downloadModel: (_modelName, _onProgress, _port) => noop,
+  reloadModel: async (port) => {
+    const p = port ?? getPythonPort();
+    await fetch(`http://127.0.0.1:${p}/models/reload`, { method: 'POST' });
+    return { success: true } as OpResult;
+  },
+
+  // Twitch — not usable in OBS mode
+  twitchStartAuth: noopPromise(undefined as void),
+  twitchGetAuthStatus: noopPromise(false),
+  twitchClearAuth: noopPromise(false),
+  twitchTestEvent: noopPromise({ success: false } as OpResult),
+  getTwitchStatus: noopPromise({ initialized: false } as TwitchStatus),
+  onTwitchAuthStatus: noopUnsubscribe,
+
+  // Profiles / Training — not usable in OBS mode
+  openTrainingWindow: noop,
+  broadcastProfilesUpdated: noop,
+  onProfilesUpdated: noopUnsubscribe,
+  onTrainingProfileChanged: noopUnsubscribe,
+};

--- a/ui/renderer/lib/obs-bridge.ts
+++ b/ui/renderer/lib/obs-bridge.ts
@@ -52,6 +52,7 @@ export const obsApi: ParceraAPI = {
   getWindowBounds: noopPromise(null as Rect | null),
   saveWindowBounds: noopPromise({ success: false } as OpResult),
   getAvatarWindowBounds: noopPromise(null as Rect | null),
+  setWindowVisible: noopPromise(undefined as void),
 
   // FS / Dialog — no-ops
   selectDirectory: noopPromise(null as string | null),

--- a/ui/renderer/lib/obs-bridge.ts
+++ b/ui/renderer/lib/obs-bridge.ts
@@ -53,6 +53,7 @@ export const obsApi: ParceraAPI = {
   saveWindowBounds: noopPromise({ success: false } as OpResult),
   getAvatarWindowBounds: noopPromise(null as Rect | null),
   setWindowVisible: noopPromise(undefined as void),
+  setWindowAlwaysOnTop: noopPromise(undefined as void),
 
   // FS / Dialog — no-ops
   selectDirectory: noopPromise(null as string | null),

--- a/ui/renderer/lib/obs-bridge.ts
+++ b/ui/renderer/lib/obs-bridge.ts
@@ -12,6 +12,9 @@ import type { ParceraSettings } from '../../shared/types';
 
 function getPythonPort(): number {
   const frontendPort = parseInt(window.location.port, 10);
+  // Vite dev server runs on 5000–6000 range; Python is still at its default port (8676)
+  if (frontendPort >= 5000 && frontendPort < 6000) return 8676;
+  // Production via tauri-plugin-localhost: frontend_port = python_port + 1
   return frontendPort > 1 ? frontendPort - 1 : 8676;
 }
 

--- a/ui/renderer/lib/tauri-bridge.ts
+++ b/ui/renderer/lib/tauri-bridge.ts
@@ -41,6 +41,7 @@ export const api: ParceraAPI = {
   },
   saveWindowBounds: (type) => invoke<OpResult>('save_window_bounds', { window_type: type }),
   getAvatarWindowBounds: (type) => invoke<Rect>('get_avatar_window_bounds', { window_type: type }),
+  setWindowVisible: (type, visible) => invoke<void>('set_window_visible', { window_type: type, visible }),
 
   // FS / Dialog
   resolveLocalPath: (filePath) => {

--- a/ui/renderer/lib/tauri-bridge.ts
+++ b/ui/renderer/lib/tauri-bridge.ts
@@ -39,10 +39,10 @@ export const api: ParceraAPI = {
       height: size.height / scale,
     };
   },
-  saveWindowBounds: (type) => invoke<OpResult>('save_window_bounds', { window_type: type }),
-  getAvatarWindowBounds: (type) => invoke<Rect>('get_avatar_window_bounds', { window_type: type }),
-  setWindowVisible: (type, visible) => invoke<void>('set_window_visible', { window_type: type, visible }),
-  setWindowAlwaysOnTop: (type, alwaysOnTop) => invoke<void>('set_window_always_on_top', { window_type: type, always_on_top: alwaysOnTop }),
+  saveWindowBounds: (type) => invoke<OpResult>('save_window_bounds', { windowType: type }),
+  getAvatarWindowBounds: (type) => invoke<Rect>('get_avatar_window_bounds', { windowType: type }),
+  setWindowVisible: (type, visible) => invoke<void>('set_window_visible', { windowType: type, visible }),
+  setWindowAlwaysOnTop: (type, alwaysOnTop) => invoke<void>('set_window_always_on_top', { windowType: type, alwaysOnTop }),
 
   // FS / Dialog
   resolveLocalPath: (filePath) => {

--- a/ui/renderer/lib/tauri-bridge.ts
+++ b/ui/renderer/lib/tauri-bridge.ts
@@ -42,6 +42,7 @@ export const api: ParceraAPI = {
   saveWindowBounds: (type) => invoke<OpResult>('save_window_bounds', { window_type: type }),
   getAvatarWindowBounds: (type) => invoke<Rect>('get_avatar_window_bounds', { window_type: type }),
   setWindowVisible: (type, visible) => invoke<void>('set_window_visible', { window_type: type, visible }),
+  setWindowAlwaysOnTop: (type, alwaysOnTop) => invoke<void>('set_window_always_on_top', { window_type: type, always_on_top: alwaysOnTop }),
 
   // FS / Dialog
   resolveLocalPath: (filePath) => {

--- a/ui/renderer/lib/visual.ts
+++ b/ui/renderer/lib/visual.ts
@@ -64,10 +64,10 @@ function updateVisuals(): void {
     avatarImage.style.setProperty('--breathe-current-scale', `${currentScale}`);
   }
 
-  // --- Audio Analysis (or external lipsync for OBS user mode) ---
+  // --- Audio Analysis (or external lipsync driven by Python MicAnalyzer) ---
   const extLipsync = getExternalLipsync();
   const env = extLipsync !== null ? extLipsync.env : getEnvelope();
-  const rmsRaw = extLipsync !== null ? extLipsync.env : getRMS();
+  const rmsRaw = extLipsync !== null ? extLipsync.rawAmplitude : getRMS(); // raw Python RMS for dB meter
   const vowel = extLipsync !== null
     ? (extLipsync.env > TALK_THRESHOLD ? (extLipsync.vowel || '-') : '-')
     : (env > TALK_THRESHOLD ? (getVowel() || '?') : '-');

--- a/ui/renderer/lib/visual.ts
+++ b/ui/renderer/lib/visual.ts
@@ -14,6 +14,11 @@ const DEFAULT_BLINK_MIN = 5000;
 const DEFAULT_BLINK_MAX = 15000;
 const DEFAULT_MOUTH_HOLD = 120; // ms — minimum time a mouth shape is held
 
+// Vowels that map to a non-standard filename (e.g. nasal → closed mouth)
+const VOWEL_FILE_OVERRIDE: Partial<Record<string, string>> = {
+  n: 'base.png', // ん: nasal consonant, mouth stays closed
+};
+
 // --- Module State ---
 let avatarImage: HTMLImageElement | null = null;
 let statusDebug: HTMLElement | null = null;
@@ -141,7 +146,7 @@ function updateVisuals(): void {
     if (nowMs > mouthHoldTimer) {
       let nextMouth = 'base.png';
       if (env > TALK_THRESHOLD && vowel && vowel !== '?') {
-        nextMouth = `${vowel}.png`;
+        nextMouth = VOWEL_FILE_OVERRIDE[vowel] ?? `${vowel}.png`;
       }
       if (nextMouth !== currentMouthFile) {
         currentMouthFile = nextMouth;
@@ -167,8 +172,24 @@ function updateVisuals(): void {
 
     if (avatarImage.src !== absoluteTarget) {
       avatarImage.src = targetPath;
+      // Reset internal state when the image fails to load (e.g. a custom avatar
+      // missing a vowel sprite). Without this, visual.ts and handleImageError
+      // fight each other every frame, causing a visible flicker loop.
+      avatarImage.onerror = () => {
+        if (targetFile !== 'base.png' && targetFile !== 'closed.png') {
+          currentMouthFile = 'base.png';
+          mouthHoldTimer = 0;
+        }
+        avatarImage!.onerror = null;
+      };
     }
   }
 
-  requestAnimationFrame(updateVisuals);
+  // Use setTimeout when the tab is hidden — rAF is throttled to ≤1 fps in
+  // background tabs and OBS browser sources, making the flicker loop visible.
+  if (document.hidden) {
+    setTimeout(updateVisuals, 33); // ~30 fps
+  } else {
+    requestAnimationFrame(updateVisuals);
+  }
 }

--- a/ui/renderer/lib/visual.ts
+++ b/ui/renderer/lib/visual.ts
@@ -79,13 +79,18 @@ function updateVisuals(): void {
     if (showDebug) {
       const db = 20 * Math.log10(Math.max(rmsRaw, 0.00001)); // floor at -100dB
 
-      // Peak meter (0 to 15 blocks, -60dB to 0dB)
+      // Peak meter (0 to 15 blocks, -55dB to -5dB)
+      // Range tuned for Python raw capture levels: typical speech sits at
+      // -25 to -45 dBFS, placing it in the center of the meter so the
+      // threshold marker is easy to read and calibrate.
       const meterSize = 15;
-      const dbRange = 60;
-      const normalizedLevel = Math.max(0, Math.min(1, (db + dbRange) / dbRange));
+      const DB_FLOOR = -55;
+      const DB_CEIL = -5;
+      const dbSpan = DB_CEIL - DB_FLOOR; // 50 dB
+      const normalizedLevel = Math.max(0, Math.min(1, (db - DB_FLOOR) / dbSpan));
       const blocksOn = Math.floor(normalizedLevel * meterSize);
 
-      const thresholdLevel = Math.max(0, Math.min(1, (state.threshold_db + dbRange) / dbRange));
+      const thresholdLevel = Math.max(0, Math.min(1, (state.threshold_db - DB_FLOOR) / dbSpan));
       const thresholdPos = Math.floor(thresholdLevel * meterSize);
 
       let meterHtml = '';
@@ -94,7 +99,7 @@ function updateVisuals(): void {
           meterHtml += '<span style="color: #ff0; font-weight: bold;">|</span>';
         } else if (i < blocksOn) {
           let color = '#eee'; // Default White
-          if (db >= -3) color = '#f44'; // Peak Red
+          if (db >= DB_CEIL) color = '#f44'; // Peak Red (at ceiling)
           else if (env > TALK_THRESHOLD) color = '#4f4'; // Active Green
           else color = '#999'; // Below threshold Grey
 

--- a/ui/renderer/lib/visual.ts
+++ b/ui/renderer/lib/visual.ts
@@ -5,7 +5,7 @@
  * debug overlay, and the requestAnimationFrame loop.
  */
 import { state } from './state';
-import { getRMS, getEnvelope, getVowel, TALK_THRESHOLD, getContext } from './audio';
+import { getRMS, getEnvelope, getVowel, getExternalLipsync, TALK_THRESHOLD, getContext } from './audio';
 import { api } from './api';
 
 // --- Constants ---
@@ -64,10 +64,13 @@ function updateVisuals(): void {
     avatarImage.style.setProperty('--breathe-current-scale', `${currentScale}`);
   }
 
-  // --- Audio Analysis ---
-  const env = getEnvelope();  // Normalized 0–1, auto-adapting
-  const rmsRaw = getRMS();    // Raw linear for dB meter
-  const vowel = env > TALK_THRESHOLD ? (getVowel() || '?') : '-';
+  // --- Audio Analysis (or external lipsync for OBS user mode) ---
+  const extLipsync = getExternalLipsync();
+  const env = extLipsync !== null ? extLipsync.env : getEnvelope();
+  const rmsRaw = extLipsync !== null ? extLipsync.env : getRMS();
+  const vowel = extLipsync !== null
+    ? (extLipsync.env > TALK_THRESHOLD ? (extLipsync.vowel || '-') : '-')
+    : (env > TALK_THRESHOLD ? (getVowel() || '?') : '-');
 
   // Debug overlay
   if (statusDebug) {

--- a/ui/renderer/tests/Avatar.test.tsx
+++ b/ui/renderer/tests/Avatar.test.tsx
@@ -36,6 +36,9 @@ vi.mock('../lib/audio', () => ({
   getEnvelope: vi.fn(() => 0),
   getRMS: vi.fn(() => 0),
   getVowel: vi.fn(() => null),
+  getExternalLipsync: vi.fn(() => null),
+  setExternalLipsync: vi.fn(),
+  clearExternalLipsync: vi.fn(),
   TALK_THRESHOLD: 0.05,
 }));
 

--- a/ui/renderer/tests/Avatar.test.tsx
+++ b/ui/renderer/tests/Avatar.test.tsx
@@ -15,6 +15,15 @@ const mockMediaDevices = {
 };
 vi.stubGlobal('navigator', { ...navigator, mediaDevices: mockMediaDevices });
 
+vi.mock('../lib/comm', () => ({
+  startWebSocket: vi.fn(),
+  startLipsyncWebSocket: vi.fn(),
+  buildWsUrl: vi.fn((port: number) => `ws://127.0.0.1:${port}/ws`),
+  buildServerUrl: vi.fn((port: number, path: string) => `http://127.0.0.1:${port}${path}`),
+  DEFAULT_PORT: 8676,
+  setupMicStreaming: vi.fn(),
+}));
+
 vi.mock('../lib/audio', () => ({
   initAudioContext: vi.fn(),
   getContext: vi.fn(() => ({
@@ -182,7 +191,11 @@ describe('Avatar Component', () => {
     }));
   });
 
-  it('requests specific microphone device when configured', async () => {
+  it('uses Python lipsync WS for user window (no getUserMedia)', async () => {
+    // User Window now delegates to Python MicAnalyzer via startLipsyncWebSocket.
+    // getUserMedia is no longer called for the user avatar.
+    const { startLipsyncWebSocket } = await import('../lib/comm');
+
     vi.mocked(api.getSettings).mockResolvedValue({
       app: { mic_device_id: 'special-mic' },
       avatars: { user: { assets_dir: '/test' } }
@@ -194,15 +207,12 @@ describe('Avatar Component', () => {
     render(<Avatar />);
 
     await waitFor(() => {
-      expect(mockGetUserMedia).toHaveBeenCalledWith(expect.objectContaining({
-        audio: expect.objectContaining({
-          deviceId: { exact: 'special-mic' }
-        })
-      }));
+      expect(vi.mocked(startLipsyncWebSocket)).toHaveBeenCalled();
+      expect(mockGetUserMedia).not.toHaveBeenCalled();
     });
   });
 
-  it('uses default microphone when no specific id is set', async () => {
+  it('does not call getUserMedia for user window', async () => {
     vi.mocked(api.getSettings).mockResolvedValue({
       app: { mic_device_id: 'default' },
       avatars: { user: { assets_dir: '/test' } }
@@ -214,11 +224,8 @@ describe('Avatar Component', () => {
     render(<Avatar />);
 
     await waitFor(() => {
-      expect(mockGetUserMedia).toHaveBeenCalledWith(expect.objectContaining({
-        audio: expect.not.objectContaining({
-          deviceId: expect.anything()
-        })
-      }));
+      expect(mockGetUserMedia).not.toHaveBeenCalled();
     });
+
   });
 });

--- a/ui/renderer/tests/SensitivityControls.test.tsx
+++ b/ui/renderer/tests/SensitivityControls.test.tsx
@@ -18,6 +18,13 @@ vi.mock('../lib/visual', () => ({
   initVisual: vi.fn(),
 }));
 
+vi.mock('../lib/comm', () => ({
+  startWebSocket: vi.fn(),
+  startLipsyncWebSocket: vi.fn(),
+  buildWsUrl: vi.fn((port: number) => `ws://127.0.0.1:${port}/ws`),
+  DEFAULT_PORT: 8676,
+}));
+
 vi.mock('@/lib/api', () => ({
   api: {
     platform: 'darwin',

--- a/ui/renderer/tests/SensitivityControls.test.tsx
+++ b/ui/renderer/tests/SensitivityControls.test.tsx
@@ -9,6 +9,9 @@ vi.mock('../lib/audio', () => ({
   getAnalyser: vi.fn(),
   connectToAnalyser: vi.fn(),
   setNoiseGateDb: vi.fn(),
+  getExternalLipsync: vi.fn(() => null),
+  setExternalLipsync: vi.fn(),
+  clearExternalLipsync: vi.fn(),
 }));
 
 vi.mock('../lib/visual', () => ({

--- a/ui/renderer/tests/lib/visual.test.ts
+++ b/ui/renderer/tests/lib/visual.test.ts
@@ -8,11 +8,14 @@ vi.mock('@/lib/api', () => ({
   },
 }));
 
-// Mock audio module — visual.ts calls getRMS/getEnvelope/getVowel every frame
+// Mock audio module — visual.ts calls getRMS/getEnvelope/getVowel/getExternalLipsync every frame
 vi.mock('@/lib/audio', () => ({
   getRMS: vi.fn(() => 0),
   getEnvelope: vi.fn(() => 0),
   getVowel: vi.fn(() => null),
+  getExternalLipsync: vi.fn(() => null),
+  setExternalLipsync: vi.fn(),
+  clearExternalLipsync: vi.fn(),
   TALK_THRESHOLD: 0.06,
   getContext: vi.fn(() => null),
 }));

--- a/ui/shared/types.ts
+++ b/ui/shared/types.ts
@@ -138,6 +138,7 @@ export interface AppSettings {
 }
 
 export interface WindowConfig {
+  visible?: boolean; // Whether the Tauri window is shown
   width?: number;
   height?: number;
   x?: number;        // Saved X position

--- a/ui/shared/types.ts
+++ b/ui/shared/types.ts
@@ -131,6 +131,7 @@ export interface VADSettings {
 
 export interface AppSettings {
   port?: number;
+  frontend_port?: number;
   ai_audio_sample_rate?: number;
   gpu_acceleration?: boolean;
   mic_device_id?: string;            // Selected microphone device ID

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,12 +1,26 @@
 import { defineConfig } from 'vite';
 import path from 'node:path';
+import { copyFileSync } from 'node:fs';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+
+// Keep ui/public/obs.html in sync with the canonical src/static/obs.html.
+// Both files must be identical: Python serves src/static/, Tauri/Vite serves public/.
+const syncObsHtml = {
+  name: 'sync-obs-html',
+  buildStart() {
+    copyFileSync(
+      path.join(__dirname, '../src/static/obs.html'),
+      path.join(__dirname, 'public/obs.html'),
+    );
+  },
+};
 
 export default defineConfig({
   plugins: [
     tailwindcss(),
     react(),
+    syncObsHtml,
   ],
   resolve: {
     alias: {

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     },
   },
   build: {
-    outDir: '../dist',
+    outDir: '../dist/web',
     emptyOutDir: true,
   },
   server: {

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ wheels = [
 
 [[package]]
 name = "parcera"
-version = "0.14.0"
+version = "0.14.1"
 source = { virtual = "." }
 dependencies = [
     { name = "aiavatar" },

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ wheels = [
 
 [[package]]
 name = "parcera"
-version = "0.13.0"
+version = "0.14.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiavatar" },

--- a/uv.lock
+++ b/uv.lock
@@ -1491,6 +1491,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "setuptools" },
+    { name = "sounddevice" },
     { name = "twitchapi" },
     { name = "uvicorn" },
 ]
@@ -1521,6 +1522,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "setuptools", specifier = ">=82.0.0" },
+    { name = "sounddevice", specifier = ">=0.5.1" },
     { name = "twitchapi", specifier = ">=4.5.0" },
     { name = "uvicorn", specifier = ">=0.46.0" },
 ]


### PR DESCRIPTION
## Overview

OBS配信者向けに**ブラウザソース対応**を追加。`obs.html` を `file://` URIとして提供することで、Parceraの起動前からOBSがアバターページをロードできるようになった。あわせてWebSocketの自動再接続により、Parcera再起動時にOBS側の手動更新が不要になる。

また、設定変更の多くを**再起動なしにリアルタイム反映**する仕組みを実装し、ユーザー体験を大幅に改善した。

---

## Changes

### 🆕 OBS Browser Source
- `src/static/obs.html` / `ui/public/obs.html`: スタンドアロンHTMLをPythonサーバーと`file://`双方から配信。Parcera未起動時もOBSがロード可能
- `obs.html` はWS接続をリトライし続け、Parcera再起動後に自動復帰（OBS手動更新不要）
- AIアバターのTTS音声をWebAudio `AnalyserNode` でデコード → スペクトル重心で母音推定 → リップシンク
- `flip_horizontal` / SVGクロマキーフィルタ / アセットキャッシュバスティング対応
- `avatarType` 別にWSメッセージハンドラとアニメーションループを分岐（AIアバターが誤ってユーザーリップシンクを使うバグを修正）
- Settings UIに `file://` URLを表示するフィールドを追加

### 🆕 Python MicAnalyzer (`src/core/mic_analyzer.py`)
- `sounddevice` ベースのマイクキャプチャをPython側で実装
- `user_lipsync` WebSocketイベント（amplitude + vowel + speaking）を全クライアントにブロードキャスト
- エネルギーベースVAD → STTパイプラインへ音声チャンクを供給
- OBSブラウザソースのUser Windowはブラウザマイク権限なしでリップシンク動作

### 🆕 Runtime Hot-reload
- VAD `silence_duration_threshold` / `max_duration`、STS `merge_request_threshold`、マイクデバイス、LLMモデル・温度を保存時即反映
- 「要再起動」バッジ（STTプロバイダー・ポート等）と文脈に応じた保存メッセージを追加

### 🆕 Window Controls
- アバターウィンドウ表示/非表示トグル（Character Settings）
- `alwaysOnTop` 保存時即適用 + 起動時復元
- `tauri-plugin-localhost` でフロントエンドを専用ポート(8677)で配信

### 🔒 Security
- `GET /config/settings` からLLM APIキー・STT/TTS APIキー・Twitch認証情報を除外

### 🐛 Bug Fixes
- STT `on_recognized` の二重呼び出し（ダブルUSERログ）を修正
- `_is_speaking` を early flush 後にリセット
- Python reloadをsaveから切り離し（保存ブロッキング解消）
- Tauri window IPC: `windowLabel` → `label` 等のキー名ズレを修正
- `merge_request_threshold` YAMLデフォルト値のズレを修正(0.6)
- mypy: `MicAnalyzer` の型アノテーション修正（`Coroutine` / `Optional[Any]`）

---

## Verification

```
pytest tests/ -v
# 136 passed, 3 warnings in 8.78s

tsc --noEmit (ui/)
# 0 errors

mypy src/core/mic_analyzer.py
# Success: no issues found in 1 source file
```

関連スペック: `docs/specs/obs-browser-source/PRD.md` / `TRD.md`