### PR TITLE
fix(twitch): restore follow events and eliminate duplicate EventSub subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.2] - 2026-05-19 - Twitch Follow Event Fix
+
+### Fixed
+- **Twitch follow events restored**: Added missing `MODERATOR_READ_FOLLOWERS` OAuth scope to `DEFAULT_SCOPES`; `listen_channel_follow_v2` silently dropped all follow events since this scope was omitted when switching from v1 in a prior commit
+- **Eliminated duplicate EventSub subscription registration**: Removed subscription calls from `_on_eventsub_ready`; subscriptions are now registered exclusively by `_subscription_worker`, preventing race-condition double-registration errors on connect
+
+> **Note**: Users must re-authenticate Twitch (re-issue token) to pick up the new scope.
+
 ## [0.14.1] - 2026-05-19 - Post-release Stabilization
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parcera"
-version = "0.14.1"
+version = "0.14.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcera"
-version = "0.14.1"
+version = "0.14.2"
 description = "Parcera - AI Avatar Companion"
 authors = []
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Parcera",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "identifier": "Parcera",
   "build": {
     "frontendDist": "../dist/web",

--- a/src/core/twitch_client.py
+++ b/src/core/twitch_client.py
@@ -19,6 +19,7 @@ class TwitchClient:
         AuthScope.CHAT_EDIT,
         AuthScope.CHANNEL_READ_SUBSCRIPTIONS,
         AuthScope.MODERATION_READ,
+        AuthScope.MODERATOR_READ_FOLLOWERS,
         AuthScope.BITS_READ,
         AuthScope.CHANNEL_READ_REDEMPTIONS
     ]
@@ -219,21 +220,9 @@ class TwitchClient:
         # Some versions pass the session object as first arg
         session_id = getattr(self.eventsub, "session_id", "Unknown")
         if session_id == "Unknown" and args:
-            # Try to grab ID from the first argument if it's there
             session_id = getattr(args[0], "session_id", "Unknown")
 
         logger.info(f"Twitch EventSub Connection Ready! Session ID: {session_id}")
-        
-        try:
-            user = await self.get_me()
-            if user:
-                logger.debug(f"Twitch: Registering subscriptions in on_ready for {user.display_name}...")
-                await self.eventsub.listen_channel_raid(self._on_raid, to_broadcaster_user_id=user.id)
-                await self.eventsub.listen_channel_follow_v2(user.id, user.id, self._on_follow)
-                await self.eventsub.listen_channel_subscribe(user.id, self._on_subscribe)
-                logger.info("Twitch: Subscriptions registered successfully via on_ready.")
-        except Exception as e:
-            logger.error(f"Failed to register subscriptions in on_ready: {e}", exc_info=True)
 
     async def _on_eventsub_error(self, event_id: str, message: str):
         """Called when EventSub encountered an error."""

--- a/tests/test_twitch_logic.py
+++ b/tests/test_twitch_logic.py
@@ -494,3 +494,40 @@ async def test_twitch_service_eventsub_handling():
         
         await cb("follow", {"user_name": "FollowUser"})
         mock_enqueue.assert_called_with("FollowUser", "Follow", event_type="follow")
+
+# --- Bug Fix Tests ---
+
+def test_default_scopes_includes_moderator_read_followers():
+    """Bug A: MODERATOR_READ_FOLLOWERS was missing, breaking listen_channel_follow_v2."""
+    from core.twitch_client import TwitchClient
+    from twitchAPI.type import AuthScope
+
+    assert AuthScope.MODERATOR_READ_FOLLOWERS in TwitchClient.DEFAULT_SCOPES, (
+        "MODERATOR_READ_FOLLOWERS must be in DEFAULT_SCOPES for follow events to work"
+    )
+
+
+@pytest.mark.anyio
+async def test_on_eventsub_ready_does_not_register_subscriptions():
+    """Bug B: _on_eventsub_ready was double-registering subscriptions alongside _subscription_worker."""
+    from core.twitch_client import TwitchClient
+
+    client = TwitchClient("id", "secret")
+
+    mock_eventsub = MagicMock()
+    mock_eventsub.listen_channel_follow_v2 = AsyncMock()
+    mock_eventsub.listen_channel_raid = AsyncMock()
+    mock_eventsub.listen_channel_subscribe = AsyncMock()
+    mock_eventsub.session_id = "test-session-123"
+    client.eventsub = mock_eventsub
+
+    mock_user = MagicMock()
+    mock_user.id = "456"
+    mock_user.display_name = "TestUser"
+    client.get_me = AsyncMock(return_value=mock_user)
+
+    await client._on_eventsub_ready()
+
+    mock_eventsub.listen_channel_follow_v2.assert_not_called()
+    mock_eventsub.listen_channel_raid.assert_not_called()
+    mock_eventsub.listen_channel_subscribe.assert_not_called()

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "parcera",
   "productName": "Parcera",
   "private": true,
-  "version": "0.14.1",
+  "version": "0.14.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ wheels = [
 
 [[package]]
 name = "parcera"
-version = "0.14.1"
+version = "0.14.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiavatar" },


### PR DESCRIPTION
## Overview

`listen_channel_follow_v2` への切り替え時（f3e7941）に `MODERATOR_READ_FOLLOWERS` OAuth スコープが `DEFAULT_SCOPES` から漏れ、フォローイベントが無音で消えていた。同時に `_on_eventsub_ready` と `_subscription_worker` の両方がサブスク登録を実行しており、接続のたびに二重登録エラーが発生しうる状態だった。

## Changes

### Bug A — `MODERATOR_READ_FOLLOWERS` スコープ欠落 (`src/core/twitch_client.py`)
- `DEFAULT_SCOPES` に `AuthScope.MODERATOR_READ_FOLLOWERS` を追加
- `listen_channel_follow_v2` は Twitch API 仕様上このスコープが必須（v1 から v2 切り替え時に追加漏れ）

### Bug B — EventSub サブスク二重登録 (`src/core/twitch_client.py`)
- `_on_eventsub_ready` からサブスク登録コード（raid / follow_v2 / subscribe）を削除
- 登録ロジックを `_subscription_worker` のみに一本化し責務を明確化
- `_on_eventsub_ready` はセッションID ログ出力のみに

### Tests (`tests/test_twitch_logic.py`)
- `test_default_scopes_includes_moderator_read_followers` — スコープ存在を静的に保証
- `test_on_eventsub_ready_does_not_register_subscriptions` — `_on_eventsub_ready` がサブスク登録しないことを動作レベルで検証

### Version bump
- `0.14.1` → `0.14.2` (patch)

## Verification

```
tests/test_twitch_logic.py .................. 18 passed
Full suite: 138 passed, 0 failed
```

> **⚠️ ユーザー対応**: スコープ変更により既存アクセストークンは再認証が必要。Twitch 再ログインを促すこと。