### PR TITLE
fix(twitch): fix OAuth callback blank white page and race conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.3] - 2026-05-19 - Twitch OAuth Callback Fix
+
+### Added
+- **OAuth Redirect URL setup hint in UI**: Twitch integration settings now show a direct link to the Twitch Developer Console with the exact redirect URI to register (`http://localhost:8678/auth/callback`), including a migration note for users who previously registered port 8677
+
+### Fixed
+- **Blank white page on OAuth callback**: `tauri-plugin-localhost` (OBS Browser Source) occupied port 8677, causing Twitch's redirect to hit the frontend server instead of the OAuth callback listener; moved OAuth callback to port 8678
+- **OAuth race condition**: Listener now binds before the browser is opened, eliminating the window where Twitch could redirect before the server was ready to accept
+- **favicon/prefetch stealing the OAuth connection**: Server now loops to skip unrelated browser requests (favicon, prefetch) and waits for the real `/auth/callback?code=...` request
+- **URL-encoded OAuth params**: `code` and `state` query parameters are now URL-decoded before use, preventing potential token-exchange failures with encoded characters
+
+> **Note**: Users must update their Twitch Developer Console OAuth Redirect URL from `http://localhost:8677/auth/callback` to `http://localhost:8678/auth/callback`.
+
 ## [0.14.2] - 2026-05-19 - Twitch Follow Event Fix
 
 ### Fixed

--- a/configs/system_vitals.yaml
+++ b/configs/system_vitals.yaml
@@ -30,4 +30,4 @@ llm:
 
 # Integration Constants
 twitch:
-  redirect_uri: "http://localhost:8677/auth/callback"
+  redirect_uri: "http://localhost:8678/auth/callback"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parcera"
-version = "0.14.2"
+version = "0.14.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "parcera"
-version = "0.14.0"
+version = "0.14.2"
 dependencies = [
  "chrono",
  "env_logger",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcera"
-version = "0.14.2"
+version = "0.14.3"
 description = "Parcera - AI Avatar Companion"
 authors = []
 edition = "2021"

--- a/src-tauri/src/twitch/oauth.rs
+++ b/src-tauri/src/twitch/oauth.rs
@@ -7,8 +7,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::time::{timeout, Duration};
 
-const OAUTH_PORT: u16 = 8677;
-const REDIRECT_URI: &str = "http://localhost:8677/auth/callback";
+// Port 8677 is occupied by tauri-plugin-localhost (OBS Browser Source frontend).
+const OAUTH_PORT: u16 = 8678;
+const REDIRECT_URI: &str = "http://localhost:8678/auth/callback";
 const AUTH_TIMEOUT_SECS: u64 = 300;
 
 const TWITCH_SCOPES: &str =
@@ -290,7 +291,7 @@ mod tests {
     fn build_auth_url_contains_redirect_uri() {
         let url = build_auth_url("id", "state");
         assert!(url.contains("redirect_uri="));
-        assert!(url.contains("8677"));
+        assert!(url.contains("8678"));
     }
 
     #[test]

--- a/src-tauri/src/twitch/oauth.rs
+++ b/src-tauri/src/twitch/oauth.rs
@@ -90,8 +90,8 @@ fn parse_callback_params(path: &str) -> Option<(String, String)> {
             Some((kv.next()?, kv.next()?))
         })
         .collect();
-    let code = params.get("code").copied()?.to_string();
-    let state = params.get("state").copied()?.to_string();
+    let code = urlencoding::decode(params.get("code").copied()?).ok()?.into_owned();
+    let state = urlencoding::decode(params.get("state").copied()?).ok()?.into_owned();
     Some((code, state))
 }
 
@@ -241,8 +241,14 @@ async fn write_http_response(
     } else {
         "text/plain"
     };
+    let status_text = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        _ => "Internal Server Error",
+    };
     let response = format!(
-        "HTTP/1.1 {status} OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "HTTP/1.1 {status} {status_text}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
     stream.write_all(response.as_bytes()).await

--- a/src-tauri/src/twitch/oauth.rs
+++ b/src-tauri/src/twitch/oauth.rs
@@ -5,9 +5,11 @@ use std::net::SocketAddr;
 use tauri::Emitter;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
 
 const OAUTH_PORT: u16 = 8677;
 const REDIRECT_URI: &str = "http://localhost:8677/auth/callback";
+const AUTH_TIMEOUT_SECS: u64 = 300;
 
 const TWITCH_SCOPES: &str =
     "chat:read chat:edit channel:read:subscriptions moderation:read \
@@ -25,23 +27,25 @@ impl TwitchOAuthHandler {
     ) -> Result<(), String> {
         let state_token = generate_state();
 
+        // Bind BEFORE opening the browser: eliminates the race condition where
+        // Twitch auto-redirects before the listener is ready.
+        let addr: SocketAddr = format!("127.0.0.1:{OAUTH_PORT}").parse().unwrap();
+        let listener = TcpListener::bind(addr).await.map_err(|e| {
+            format!("Failed to bind OAuth callback port {OAUTH_PORT} (already in use?): {e}")
+        })?;
+
         let auth_url = build_auth_url(&client_id, &state_token);
         tauri_plugin_opener::open_url(auth_url, Option::<String>::None)
             .map_err(|e| e.to_string())?;
 
-        let state_token_clone = state_token.clone();
-        let client_id_clone = client_id.clone();
-        let client_secret_clone = client_secret.clone();
-        let token_store_clone = token_store.clone();
-        let app_handle_clone = app_handle.clone();
-
         tokio::spawn(async move {
             if let Err(e) = run_callback_server(
-                state_token_clone,
-                client_id_clone,
-                client_secret_clone,
-                token_store_clone,
-                app_handle_clone,
+                listener,
+                state_token,
+                client_id,
+                client_secret,
+                token_store,
+                app_handle,
                 python_port,
             )
             .await
@@ -69,6 +73,25 @@ fn build_auth_url(client_id: &str, state: &str) -> String {
          &state={state}",
         urlencoding::encode(TWITCH_SCOPES)
     )
+}
+
+/// Extracts (code, state) from a callback path if it is a valid /auth/callback request.
+/// Returns None for unrelated paths (e.g. /favicon.ico) so the server can skip them.
+fn parse_callback_params(path: &str) -> Option<(String, String)> {
+    if !path.starts_with("/auth/callback") {
+        return None;
+    }
+    let query = path.splitn(2, '?').nth(1).unwrap_or("");
+    let params: std::collections::HashMap<&str, &str> = query
+        .split('&')
+        .filter_map(|p| {
+            let mut kv = p.splitn(2, '=');
+            Some((kv.next()?, kv.next()?))
+        })
+        .collect();
+    let code = params.get("code").copied()?.to_string();
+    let state = params.get("state").copied()?.to_string();
+    Some((code, state))
 }
 
 async fn sync_tokens_with_python(port: u16, tokens: &TwitchTokens) {
@@ -101,6 +124,7 @@ fn build_sync_url(port: u16) -> String {
 }
 
 async fn run_callback_server(
+    listener: TcpListener,
     expected_state: String,
     client_id: String,
     client_secret: String,
@@ -108,64 +132,61 @@ async fn run_callback_server(
     app_handle: tauri::AppHandle,
     python_port: u16,
 ) -> Result<(), String> {
-    let addr: SocketAddr = format!("127.0.0.1:{OAUTH_PORT}").parse().unwrap();
-    let listener = TcpListener::bind(addr).await.map_err(|e| e.to_string())?;
+    // Loop to skip unrelated browser requests (favicon, prefetch, etc.) that
+    // arrive before the actual /auth/callback?code=...&state=... request.
+    loop {
+        let (mut stream, _) = timeout(
+            Duration::from_secs(AUTH_TIMEOUT_SECS),
+            listener.accept(),
+        )
+        .await
+        .map_err(|_| "OAuth callback timed out after 5 minutes".to_string())?
+        .map_err(|e| e.to_string())?;
 
-    // Accept a single connection then close the server
-    let (mut stream, _) = listener.accept().await.map_err(|e| e.to_string())?;
+        let mut buf = vec![0u8; 4096];
+        let n = stream.read(&mut buf).await.map_err(|e| e.to_string())?;
+        if n == 0 {
+            continue;
+        }
+        let request = String::from_utf8_lossy(&buf[..n]);
 
-    let mut buf = vec![0u8; 4096];
-    let n = stream.read(&mut buf).await.map_err(|e| e.to_string())?;
-    let request = String::from_utf8_lossy(&buf[..n]);
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("/");
 
-    // Extract the request path from the first line
-    let path = request
-        .lines()
-        .next()
-        .and_then(|line| line.split_whitespace().nth(1))
-        .unwrap_or("/");
+        let (code, state) = match parse_callback_params(path) {
+            None => {
+                // Not the auth callback (e.g. /favicon.ico) — acknowledge and keep waiting.
+                let _ = write_http_response(&mut stream, 404, "Not found").await;
+                continue;
+            }
+            Some(params) => params,
+        };
 
-    let query = path.splitn(2, '?').nth(1).unwrap_or("");
-    let params: std::collections::HashMap<&str, &str> = query
-        .split('&')
-        .filter_map(|p| {
-            let mut kv = p.splitn(2, '=');
-            Some((kv.next()?, kv.next()?))
-        })
-        .collect();
+        if state != expected_state {
+            let _ = write_http_response(&mut stream, 400, ERROR_HTML).await;
+            return Err("State mismatch in OAuth callback".into());
+        }
 
-    let code = params.get("code").copied();
-    let state = params.get("state").copied();
-
-    if state != Some(expected_state.as_str()) {
-        let _ = write_http_response(&mut stream, 400, "State mismatch").await;
-        return Err("State mismatch in OAuth callback".into());
-    }
-
-    if let Some(code) = code {
-        match exchange_code(&client_id, &client_secret, code).await {
+        match exchange_code(&client_id, &client_secret, &code).await {
             Ok(tokens) => {
                 token_store.save(&tokens).map_err(|e| e.to_string())?;
                 let _ = write_http_response(&mut stream, 200, SUCCESS_HTML).await;
                 let _ = app_handle.emit("twitch-auth-status", serde_json::json!({ "success": true }));
-                // Sync tokens to Python backend in background (with retry).
-                // Must happen after save so restart also re-syncs from token_store.
                 let tokens_clone = tokens.clone();
                 tokio::spawn(async move {
                     sync_tokens_with_python(python_port, &tokens_clone).await;
                 });
+                return Ok(());
             }
             Err(e) => {
-                let _ = write_http_response(&mut stream, 500, &e).await;
+                let _ = write_http_response(&mut stream, 500, ERROR_HTML).await;
                 return Err(e);
             }
         }
-    } else {
-        let _ = write_http_response(&mut stream, 400, "Authorization code missing").await;
-        return Err("Authorization code missing".into());
     }
-
-    Ok(())
 }
 
 async fn exchange_code(
@@ -235,6 +256,14 @@ const SUCCESS_HTML: &str = r#"<html>
   </body>
 </html>"#;
 
+const ERROR_HTML: &str = r#"<html>
+  <body style="font-family:sans-serif;display:flex;flex-direction:column;align-items:center;
+               justify-content:center;height:100vh;background:#0f0f0f;color:white;">
+    <h1 style="color:#ff4444;">Authentication Failed</h1>
+    <p>Something went wrong. Please close this window and try again in Parcera.</p>
+  </body>
+</html>"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,5 +318,31 @@ mod tests {
         let url = build_sync_url(9999);
         assert!(url.contains(":9999/"));
         assert!(url.ends_with("/twitch/init"));
+    }
+
+    #[test]
+    fn parse_callback_params_extracts_code_and_state() {
+        let result = parse_callback_params("/auth/callback?code=abc123&state=xyz789");
+        assert_eq!(result, Some(("abc123".to_string(), "xyz789".to_string())));
+    }
+
+    #[test]
+    fn parse_callback_params_ignores_non_callback_paths() {
+        assert!(parse_callback_params("/favicon.ico").is_none());
+        assert!(parse_callback_params("/").is_none());
+        assert!(parse_callback_params("/auth/other").is_none());
+    }
+
+    #[test]
+    fn parse_callback_params_requires_both_code_and_state() {
+        assert!(parse_callback_params("/auth/callback?code=abc").is_none());
+        assert!(parse_callback_params("/auth/callback?state=xyz").is_none());
+        assert!(parse_callback_params("/auth/callback").is_none());
+    }
+
+    #[test]
+    fn parse_callback_params_handles_extra_query_params() {
+        let result = parse_callback_params("/auth/callback?scope=chat%3Aread&code=tok&state=st");
+        assert_eq!(result, Some(("tok".to_string(), "st".to_string())));
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Parcera",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "identifier": "Parcera",
   "build": {
     "frontendDist": "../dist/web",

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "parcera",
   "productName": "Parcera",
   "private": true,
-  "version": "0.14.2",
+  "version": "0.14.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/ui/renderer/components/sections/IntegrationSection.tsx
+++ b/ui/renderer/components/sections/IntegrationSection.tsx
@@ -90,6 +90,19 @@ export const IntegrationSection: React.FC<SectionProps> = ({
                 placeholder="Twitch App Client Secret"
               />
             </FieldRow>
+            <p className="text-xs text-muted-foreground">
+              <a
+                href="https://dev.twitch.tv/console"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                Twitch Developer Console
+              </a>
+              のアプリ設定で OAuth Redirect URL に{' '}
+              <code className="bg-muted px-1 rounded text-xs">http://localhost:8678/auth/callback</code>{' '}
+              を登録してください。
+            </p>
             <div className="flex items-center gap-3 mt-2">
               {isAuthorized ? (
                 <>

--- a/ui/renderer/components/sections/IntegrationSection.tsx
+++ b/ui/renderer/components/sections/IntegrationSection.tsx
@@ -101,7 +101,7 @@ export const IntegrationSection: React.FC<SectionProps> = ({
               </a>
               のアプリ設定で OAuth Redirect URL に{' '}
               <code className="bg-muted px-1 rounded text-xs">http://localhost:8678/auth/callback</code>{' '}
-              を登録してください。
+              を登録してください。以前 8677 で登録していた場合は 8678 に変更してください。
             </p>
             <div className="flex items-center gap-3 mt-2">
               {isAuthorized ? (

--- a/uv.lock
+++ b/uv.lock
@@ -1473,7 +1473,7 @@ wheels = [
 
 [[package]]
 name = "parcera"
-version = "0.14.2"
+version = "0.14.3"
 source = { virtual = "." }
 dependencies = [
     { name = "aiavatar" },


### PR DESCRIPTION
## Overview

Twitch OAuth 認証後にコールバックページが真っ白になる問題を修正する。根本原因は `tauri-plugin-localhost`（OBS Browser Source 用フロントエンドサーバー）がポート 8677 を常時占有しており、OAuth コールバックサーバーと競合していたこと。Electron→Tauri 移行時に OBS Browser Source 機能が追加された際に生まれた競合。

## Changes

- **ポート競合の解消** (`oauth.rs`): OAuth コールバックポートを 8677 → 8678 に変更。`tauri-plugin-localhost` が 8677 を常時バインドしているため、Twitch のリダイレクト先がフロントエンドサーバーに当たり `/auth/callback` ルートがなく真っ白になっていた
- **レースコンディション修正** (`oauth.rs`): ブラウザを開く前に `TcpListener::bind` するよう変更。従来は spawned task 内でバインドしており、Twitch がリダイレクトした時点でリスナーが未起動の場合があった
- **favicon 横取り対策** (`oauth.rs`): `run_callback_server` を single-accept からループ accept に変更。ブラウザが並行送信する favicon/prefetch をスキップして本物の `/auth/callback?code=...` を待つ
- **5分タイムアウト追加** (`oauth.rs`): 認証未完了のリスナーが永続しないよう `tokio::time::timeout` を追加
- **URL デコード追加** (`oauth.rs`): `code`・`state` クエリパラメータを `urlencoding::decode` してから使用
- **エラーページ追加** (`oauth.rs`): 認証失敗時に `ERROR_HTML` を返す。HTTP ステータステキストも正確な値に修正
- **`parse_callback_params` 抽出** (`oauth.rs`): パース処理を純粋関数に分離しユニットテスト 4 件追加
- **UI セットアップ案内追加** (`IntegrationSection.tsx`): Client Secret 欄直下に Twitch Developer Console へのリンクと登録すべき Redirect URI を表示。8677 からの移行案内も添付
- **`system_vitals.yaml` 更新**: ドキュメント用 `redirect_uri` を 8678 に更新

## Verification

```
cargo test --lib       → 64 passed
uv run pytest tests/  → 138 passed
IntegrationSection.test.tsx → 12 passed
```

> **⚠️ Breaking**: Twitch Developer Console の OAuth Redirect URL を `http://localhost:8677/auth/callback` → `http://localhost:8678/auth/callback` に更新が必要。設定画面に案内を追記済み。