### PR TITLE
ci: add GitHub Actions Mac/Windows cross-build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,72 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest
+            sidecar_script: bash scripts/prepare_sidecar.sh
+          - os: windows-latest
+            sidecar_script: pwsh scripts/prepare_sidecar.ps1
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install frontend dependencies
+        run: pnpm -C ui install
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Prepare Python sidecar
+        run: ${{ matrix.sidecar_script }}
+
+      - name: Build Tauri app
+        run: pnpm exec tauri build
+        working-directory: ui
+
+      - name: Upload macOS artifacts
+        if: runner.os == 'macOS'
+        uses: actions/upload-artifact@v4
+        with:
+          name: parcera-macos
+          path: src-tauri/target/release/bundle/dmg/*.dmg
+          if-no-files-found: warn
+
+      - name: Upload Windows artifacts
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@v4
+        with:
+          name: parcera-windows
+          path: |
+            src-tauri/target/release/bundle/msi/*.msi
+            src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: warn

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "parcera"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "chrono",
  "env_logger",

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -51,14 +51,46 @@ impl SidecarManager {
         self.spawn_python(app).await;
     }
 
-    /// Kill any process currently bound to our port (macOS/Linux: via lsof).
+    /// Kill any process currently bound to our port.
+    /// macOS/Linux: lsof. Windows: netstat + taskkill.
     /// Ignores errors — if nothing is there, that's fine.
+    #[cfg(not(target_os = "windows"))]
     async fn evict_port_occupant(&self) {
         let port = self.port;
         let result = tokio::task::spawn_blocking(move || {
             std::process::Command::new("sh")
                 .args(["-c", &format!("lsof -ti tcp:{port} | xargs kill -9 2>/dev/null; exit 0")])
                 .status()
+        }).await;
+        if result.is_ok() {
+            tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn evict_port_occupant(&self) {
+        let port = self.port;
+        let result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+            let output = std::process::Command::new("netstat")
+                .args(["-ano"])
+                .output()?;
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            for line in stdout.lines() {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                // netstat -ano columns: Proto, Local, Foreign, State, PID
+                if parts.len() >= 5
+                    && parts[1].ends_with(&format!(":{port}"))
+                    && parts[3] == "LISTENING"
+                {
+                    if let Some(pid) = parts.last() {
+                        let _ = std::process::Command::new("taskkill")
+                            .args(["/F", "/PID", pid])
+                            .status();
+                    }
+                    break;
+                }
+            }
+            Ok(())
         }).await;
         if result.is_ok() {
             tokio::time::sleep(tokio::time::Duration::from_millis(600)).await;

--- a/src-tauri/src/sidecar.rs
+++ b/src-tauri/src/sidecar.rs
@@ -215,8 +215,16 @@ impl SidecarManager {
 // ── Path resolution helpers ────────────────────────────────────────────────
 
 /// Path to the Python binary inside a bundled resource directory.
+/// macOS/Linux standalone: python-runtime/bin/python
+/// Windows standalone: python-runtime/python.exe (no bin/ subdirectory)
+#[cfg(not(target_os = "windows"))]
 pub fn python_bin_path(resource_dir: &Path) -> PathBuf {
     resource_dir.join("python-runtime").join("bin").join("python")
+}
+
+#[cfg(target_os = "windows")]
+pub fn python_bin_path(resource_dir: &Path) -> PathBuf {
+    resource_dir.join("python-runtime").join("python.exe")
 }
 
 /// Path to run_server.py inside a bundled resource directory.
@@ -293,10 +301,19 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "windows"))]
     fn python_bin_path_resolves_correctly() {
         let dir = PathBuf::from("/resources");
         let p = python_bin_path(&dir);
         assert!(p.to_string_lossy().ends_with("python-runtime/bin/python"), "got: {}", p.display());
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn python_bin_path_resolves_correctly() {
+        let dir = PathBuf::from("C:\\resources");
+        let p = python_bin_path(&dir);
+        assert!(p.to_string_lossy().ends_with("python-runtime\\python.exe"), "got: {}", p.display());
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,9 @@
     },
     "windows": {
       "nsis": {},
-      "wix": {}
+      "wix": {
+        "upgradeCode": "2818B657-ED1A-4B94-BA70-EFB15D062029"
+      }
     },
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,6 +51,10 @@
       "minimumSystemVersion": "12.0",
       "infoPlist": "Info.plist"
     },
+    "windows": {
+      "nsis": {},
+      "wix": {}
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Overview

CI がゼロの状態から、タグ push をトリガーとする macOS / Windows のクロスビルド環境を GitHub Actions で構築した。  
合わせて、Windows でビルドが通るよう Rust コードと Tauri 設定を修正している。

Windows 対応には単なる CI 追加にとどまらず、これまで macOS 専用だった `evict_port_occupant`（lsof）と `python_bin_path`（bin/python）の2か所が実行時にサイレントに失敗していた問題の修正も含む。

## Changes

### `src-tauri/src/sidecar.rs`

- **`evict_port_occupant` の Windows 対応** (`#[cfg]` 分岐)
  - `#[cfg(not(target_os = "windows"))]`: 既存の `lsof` + `xargs kill -9` 実装を維持
  - `#[cfg(target_os = "windows")]`: `netstat -ano` でポート使用中 PID を特定し `taskkill /F /PID` で強制終了

- **`python_bin_path()` の Windows 対応** (`#[cfg]` 分岐)
  - macOS/Linux: `python-runtime/bin/python`（変更なし）
  - Windows: `python-runtime/python.exe`（Windows standalone tarball は `bin/` サブディレクトリを持たない）
  - `python_bin_path_resolves_correctly` テストも `#[cfg]` で分岐

### `.github/workflows/build.yml` (新規)

- **Trigger**: `push: tags: v*` + `workflow_dispatch`
- **Matrix**: `macos-latest` / `windows-latest` の並列ビルド
- **Steps**: Rust stable → Node.js 22 → pnpm 10 → uv → OS別サイドカー準備 → `tauri build` → artifacts upload
- `Swatinem/rust-cache` で Rust ビルドキャッシュを有効化
- macOS artifacts: `parcera-macos` (DMG)
- Windows artifacts: `parcera-windows` (MSI + NSIS EXE)

### `src-tauri/tauri.conf.json`

- `bundle.windows.nsis: {}` — NSIS インストーラーを有効化
- `bundle.windows.wix.upgradeCode: "2818B657-ED1A-4B94-BA70-EFB15D062029"` — 安定 UUID を固定（未設定だとビルドごとにランダム GUID が生成され、MSI のクリーンアップグレードが不可能になる）

## Verification

```
cargo test: 64 passed, 0 failed
cargo check: Finished (no new errors introduced)
YAML: python3 yaml.safe_load → OK
JSON: python3 json.load → OK
```

既存の Clippy 警告 (`oauth.rs:85` split_once, `LogManager` new-without-default) はこのブランチ以前から存在するもので、今回の変更は新規 Clippy エラーを導入していない。

## Out of Scope

- コードサイニング（Apple Developer / EV 証明書）— 別タスク
- GitHub Release への成果物自動添付 — 別タスク